### PR TITLE
[Gateway] Release 2.3.0

### DIFF
--- a/charts/gateway/Chart.yaml
+++ b/charts/gateway/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
-appVersion: "2.2.1"
+appVersion: "2.3.0"
 description: Conduktor Gateway and associated backing Kafka
 name: conduktor-gateway
-version: 2.2.3
+version: 2.3.0
 
 dependencies:
   - name: kafka

--- a/charts/gateway/values.yaml
+++ b/charts/gateway/values.yaml
@@ -21,7 +21,7 @@ gateway:
     ## @param gateway.image.repository Image in repository format (conduktor/conduktor-gateway)
     repository: conduktor/conduktor-gateway
     ## @param gateway.image.tag Image tag
-    tag: 2.1.0
+    tag: 2.3.0
     ## @param gateway.image.pullPolicy Kubernetes image pull policy
     pullPolicy: IfNotPresent
 


### PR DESCRIPTION
## What does this PR do ? 
Update gateway chart to 2.3.0
Change default version to 2.3.0 for gateway