### PR TITLE
Bump gateway chart version to 2.3.2

### DIFF
--- a/charts/gateway/Chart.yaml
+++ b/charts/gateway/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "2.3.1"
 description: Conduktor Gateway and associated backing Kafka
 name: conduktor-gateway
-version: 2.3.1
+version: 2.3.2
 
 dependencies:
   - name: kafka

--- a/charts/gateway/values.yaml
+++ b/charts/gateway/values.yaml
@@ -42,7 +42,7 @@ gateway:
   ##      secretKeyRef:
   ##        name: secret-test
   ##        key: SECRET_2
-  extraSecretEnvVars: [ ]
+  extraSecretEnvVars: []
   ## @param gateway.secretSha256sum [nullable] Optional sha256sum of the referenced secret. This could be set to have a automactic restart of gateway deployment if secret change
   secretSha256sum: ""
 


### PR DESCRIPTION
To [fix current chart release process](https://github.com/conduktor/conduktor-public-charts/actions/runs/7318487159/job/19935199277#step:7:52), bump the gateway chart version to 2.3.2
And fix lint failure from https://github.com/conduktor/conduktor-public-charts/pull/41

cc @fteychene @vuduchailinh 