### PR TITLE
feat(metrics): allow `ServiceMonitor` extra parameters setting for gateway

### DIFF
--- a/.github/workflows/chart-test.yaml
+++ b/.github/workflows/chart-test.yaml
@@ -21,7 +21,6 @@ jobs:
       - uses: actions/checkout@v3
         name: Checkout Conduktor Charts
         with:
-          ref: ${{ github.event.pull_request.head.ref }}
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Fetch history

--- a/.github/workflows/generate-readme.yaml
+++ b/.github/workflows/generate-readme.yaml
@@ -25,7 +25,6 @@ jobs:
       - uses: actions/checkout@v3
         name: Checkout Conduktor Charts
         with:
-          ref: ${{ github.event.pull_request.head.ref }}
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Execute readme-generator-for-helm

--- a/charts/gateway/README.md
+++ b/charts/gateway/README.md
@@ -94,6 +94,7 @@ Gateway embed metrics to be installed within you cluster if your have the correc
 | `metrics.prometheus.enable`              | Enable ServiceMonitor prometheus operator configuration for metrics scrapping | `false`      |
 | `metrics.prometheus.metricRelabelings`   | Configure metric relabeling in ServiceMonitor                                 | `{}`         |
 | `metrics.prometheus.relabelings`         | Configure relabelings in ServiceMonitor                                       | `{}`         |
+| `metrics.prometheus.extraParams`         | Extra parameters in ServiceMonitor                                            | `{}`         |
 | `metrics.grafana.enable`                 | Enable grafana dashboards to installation                                     | `false`      |
 | `metrics.grafana.datasources.prometheus` | Prometheus datasource to use for metric dashboard                             | `prometheus` |
 | `metrics.grafana.datasources.loki`       | Loki datasource to use for log dashboard                                      | `loki`       |

--- a/charts/gateway/templates/prometheus-monitoring.yaml
+++ b/charts/gateway/templates/prometheus-monitoring.yaml
@@ -19,5 +19,8 @@ spec:
       {{- if .Values.metrics.prometheus.relabelings }}
       relabelings: {{- include "common.tplvalues.render" ( dict "value" .Values.metrics.prometheus.relabelings "context" $) | nindent 8 }}
       {{- end }}
+      {{- if .Values.metrics.prometheus.extraParams }}
+      {{- toYaml .Values.metrics.prometheus.extraParams | nindent 6 }}
+      {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/gateway/values.yaml
+++ b/charts/gateway/values.yaml
@@ -158,6 +158,15 @@ metrics:
     metricRelabelings: {}
     ## @param metrics.prometheus.relabelings Configure relabelings in ServiceMonitor
     relabelings: {}
+    ## @param metrics.prometheus.extraParams Extra parameters in ServiceMonitor
+    extraParams: {}
+      # basicAuth:
+      #   password:
+      #     name: conduktor-admin-user # secret name
+      #     key: password
+      #   username:
+      #     name: conduktor-admin-user # secret name
+      #     key: username
   grafana:
     ## @param metrics.grafana.enable Enable grafana dashboards to installation
     enable: false


### PR DESCRIPTION
## Context

Provide the possibility to add extra parameters in the spec.endpoints[0] section in order to properly configure the `ServiceMonitor` resource, for example to configure authentication method.

## Related issues

Fixes #60 