### PR TITLE
Fix: create-release workflow

### DIFF
--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -34,6 +34,7 @@ permissions:
   contents: write
   pull-requests: write
 
+
 jobs:
   create-release:
     runs-on: ubuntu-latest
@@ -47,11 +48,27 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
+          token: ${{ secrets.CONDUKTORBOT_REPO_WRITE }}
 
       - name: Install Helm
         uses: azure/setup-helm@v3
         with:
           version: "v3.10.1"
+
+      - name: Install Chart Releaser
+        env:
+          CR_VERSION: 1.6.1
+          CR_BIN_PATH: "/opt/hostedtoolcache/chart-releaser"
+        run: |
+          echo $PATH
+
+          mkdir -p ${{ env.CR_BIN_PATH }}
+          wget -O /tmp/cr.tar.gz https://github.com/helm/chart-releaser/releases/download/v${{env.CR_VERSION}}/chart-releaser_${{CR_VERSION}}_linux_amd64.tar.gz
+          tar -xzvf /tmp/cr.tar.gz -C ${{ env.CR_BIN_PATH }}
+          sudo chmod +x ${{ env.CR_BIN_PATH }}/cr
+          echo "${{env.CR_BIN_PATH}}" >> $GITHUB_PATH
+
+          echo "Chart releaser installed at ${{env.CR_BIN_PATH}}"
 
       - name: Update chart version
         uses: mikefarah/yq@master
@@ -85,14 +102,8 @@ jobs:
       - name: Package chart ${{ inputs.chart }}
         id: package
         run: |
-          id
-          docker run \
-            --user "${UID}:${GID}" \
-            --workdir /chart \
-            -v ${{ env.CHART_DIR }}:/chart \
-            quay.io/helmpack/chart-releaser \
-            package /chart --package-path .cr-release-packages
-
+          cr version
+          cr package ${{ env.CHART_DIR }} --package-path ${{ env.CHART_DIR }}/.cr-release-packages
           echo "package_file=${{ env.CHART_DIR }}/.cr-release-packages/${{ inputs.chart }}-${{ inputs.version }}.tgz" >> "${GITHUB_OUTPUT}"
 
       - name: Create github release ${{ env.RELEASE_NAME }}
@@ -120,9 +131,11 @@ jobs:
           owner=$(cut -d '/' -f 1 <<< "$GITHUB_REPOSITORY")
           repo=$(cut -d '/' -f 2 <<< "$GITHUB_REPOSITORY")
 
-          docker run \
-            --user "${UID}:${GID}" \
-            --workdir /workdir \
-            -v $(pwd):/workdir \
-            quay.io/helmpack/chart-releaser \
-            index --index-path index.yaml --push -r "$repo" -o "$owner" --package-path ./charts/${{ inputs.chart }}/.cr-release-packages --token ${{ env.GITHUB_TOKEN }}
+          cr version
+          cr index \
+            --index-path index.yaml \
+            --push \
+            -r "$repo" \
+            -o "$owner" \
+            --package-path ${{ env.CHART_DIR }}/.cr-release-packages \
+            --token ${{ secrets.CONDUKTORBOT_REPO_WRITE }}


### PR DESCRIPTION
- fix auto-commit using ConduktorBot account 
- install chart-releaser directly on runner instead of using docker image to allow GPG commits signature