### PR TITLE
Add missing bitnami repository definition

### DIFF
--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -55,6 +55,9 @@ jobs:
         with:
           version: "v3.10.1"
 
+      - name: Add bitnami repository
+        run: helm repo add bitnami https://charts.bitnami.com/bitnami
+        
       - name: Install Chart Releaser
         env:
           CR_VERSION: 1.6.1


### PR DESCRIPTION
Fix chart-releaser error `Error: no repository definition for https://charts.bitnami.com/bitnami` by adding bitnami repository to current helm context