### PR TITLE
Reset gateway chart version to 3.1.0

### DIFF
--- a/charts/gateway/Chart.yaml
+++ b/charts/gateway/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "3.1.1"
 description: Conduktor Gateway chart
 name: conduktor-gateway
-version: 3.1.1
+version: 3.1.0
 dependencies:
   - name: kafka
     repository: https://charts.bitnami.com/bitnami


### PR DESCRIPTION
Version bump rolled back since it is the release jobs work