### PR TITLE
Gateway: `tls.enable` for tls configuration

### DIFF
--- a/charts/gateway/templates/deployment.yaml
+++ b/charts/gateway/templates/deployment.yaml
@@ -111,7 +111,7 @@ spec:
         {{- if .Values.tls.enable }}
         - name: keystore
           secret:
-            secretName: {{ required "A .tls.secretRef is required when .tls.enabled is true" .Values.tls.secretRef }}
+            secretName: {{ required "A .tls.secretRef is required when .tls.enable is true" .Values.tls.secretRef }}
             items:
             - key: {{ .Values.tls.keystoreKey }}
               path: {{ .Values.tls.keystoreFile }}

--- a/charts/gateway/templates/deployment.yaml
+++ b/charts/gateway/templates/deployment.yaml
@@ -50,7 +50,7 @@ spec:
             - name: JAVA_TOOL_OPTIONS
               value: {{ tpl .Values.gateway.jmx.jvmArgs . | quote }}
             {{- end}}
-            {{- if .Values.tls.secretRef}}
+            {{- if and .Values.tls.enable .Values.tls.secretRef}}
             - name: GATEWAY_SSL_KEY_STORE_PATH
               value: /etc/gateway/tls/{{ .Values.tls.keystoreFile }}
             {{- end }}
@@ -81,7 +81,7 @@ spec:
             {{- with .Values.gateway.volumeMounts }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
-            {{- if .Values.tls.secretRef }}
+            {{- if and .Values.tls.enable .Values.tls.secretRef }}
             - name: keystore
               mountPath: /etc/gateway/tls/
               readOnly: true
@@ -108,10 +108,10 @@ spec:
         {{- with .Values.gateway.volumes }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
-        {{- if .Values.tls.secretRef }}
+        {{- if .Values.tls.enable }}
         - name: keystore
           secret:
-            secretName: {{ .Values.tls.secretRef }}
+            secretName: {{ required "A .tls.secretRef is required when .tls.enabled is true" .Values.tls.secretRef }}
             items:
             - key: {{ .Values.tls.keystoreKey }}
               path: {{ .Values.tls.keystoreFile }}


### PR DESCRIPTION
## What does this PR do ?

Use `.Values.tls.enable` for tls env var, volume and secret configuration in Gateway deployment

## Rel

Fixes #90 