### PR TITLE
feat(deployment): allow existing service account usage

### DIFF
--- a/charts/gateway/Chart.yaml
+++ b/charts/gateway/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "3.2.1"
 description: Conduktor Gateway chart
 name: conduktor-gateway
-version: 3.2.2
+version: 3.2.1
 dependencies:
   - name: kafka
     repository: https://charts.bitnami.com/bitnami

--- a/charts/gateway/Chart.yaml
+++ b/charts/gateway/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "3.2.1"
 description: Conduktor Gateway chart
 name: conduktor-gateway
-version: 3.2.1
+version: 3.2.2
 dependencies:
   - name: kafka
     repository: https://charts.bitnami.com/bitnami

--- a/charts/gateway/README.md
+++ b/charts/gateway/README.md
@@ -16,6 +16,7 @@ helm install myGateway conduktor/conduktor-gateway
 
 This section contains configuration of the gateway
 
+
 ### Conduktor-gateway image configuration
 
 This section define the image to be used
@@ -59,6 +60,7 @@ This section is for configuring gateway to handle certificate to manage SSL endp
 ### Conduktor-gateway service configurations
 
 This section contains kubernetes services configuration
+
 
 ### Conduktor-gateway external service configurations
 

--- a/charts/gateway/README.md
+++ b/charts/gateway/README.md
@@ -16,7 +16,6 @@ helm install myGateway conduktor/conduktor-gateway
 
 This section contains configuration of the gateway
 
-
 ### Conduktor-gateway image configuration
 
 This section define the image to be used
@@ -60,7 +59,6 @@ This section is for configuring gateway to handle certificate to manage SSL endp
 ### Conduktor-gateway service configurations
 
 This section contains kubernetes services configuration
-
 
 ### Conduktor-gateway external service configurations
 
@@ -106,6 +104,7 @@ Shared kubernetes configuration of the chart
 | Name                    | Description                                                    | Value   |
 | ----------------------- | -------------------------------------------------------------- | ------- |
 | `serviceAccount.create` | Create Kubernetes service account. Default kube value if false | `false` |
+| `serviceAccount.name`   | Service account name to attach to the Gateway deployment       | `""`    |
 | `commonLabels`          | Labels to be applied to all ressources created by this chart   | `{}`    |
 | `nodeSelector`          | Container node selector                                        | `{}`    |
 | `tolerations`           | Container tolerations                                          | `[]`    |
@@ -118,4 +117,3 @@ Enable and configure chart dependencies if not available in your deployment
 | Name            | Description                                                                   | Value   |
 | --------------- | ----------------------------------------------------------------------------- | ------- |
 | `kafka.enabled` | Deploy a kafka along side gateway (This should only used for testing purpose) | `false` |
-

--- a/charts/gateway/templates/deployment.yaml
+++ b/charts/gateway/templates/deployment.yaml
@@ -122,9 +122,7 @@ spec:
             items:
             - key: interceptors.json
               path: interceptors.json
-      {{- if .Values.serviceAccount.create }}
       serviceAccountName: {{ template "conduktor-gateway.serviceAccountName" . }}
-      {{- end }}
       {{- with .Values.global.imagePullSecrets }}
       imagePullSecrets: {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/gateway/values.yaml
+++ b/charts/gateway/values.yaml
@@ -187,6 +187,8 @@ serviceAccount:
   # Specifies whether a service account should be created
   # If AWS IAM is used, need to have create: false
   create: false
+  ## @param serviceAccount.name Service account name to attach to the Gateway deployment
+  name: ""
 
 ## @param commonLabels Labels to be applied to all ressources created by this chart
 commonLabels: {}


### PR DESCRIPTION
# Context

Allow to use an existing service account in `Deployment` Kubernetes resource configuration without having to create one with this chart.

# Implementation details

The parameter `serviceAccount.name` was already used to compute `conduktor-gateway.serviceAccountName` but not documented in the values list. Therefore we can always set the `serviceAccountName` parameter of the `Deployment` Kubernetes resource as it will take the `default`  one if nothing is specified.

# Related issues

Fixes #101 