### PR TITLE
Release helm chart conduktor-gateway_3.3.0

### DIFF
--- a/charts/gateway/Chart.yaml
+++ b/charts/gateway/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
-appVersion: "3.2.2"
+appVersion: "3.3.0"
 description: Conduktor Gateway chart
 name: conduktor-gateway
-version: 3.2.2
+version: 3.3.0
 dependencies:
   - name: kafka
     repository: https://charts.bitnami.com/bitnami

--- a/charts/gateway/README.md
+++ b/charts/gateway/README.md
@@ -20,7 +20,7 @@ This section defines the image to be used.
 | -------------------------- | -------------------------------------------------------- | ----------------------------- |
 | `gateway.image.registry`   | Docker registry to use                                   | `docker.io`                   |
 | `gateway.image.repository` | Image in repository format (conduktor/conduktor-gateway) | `conduktor/conduktor-gateway` |
-| `gateway.image.tag`        | Image tag                                                | `3.2.2`                       |
+| `gateway.image.tag`        | Image tag                                                | `3.3.0`                       |
 | `gateway.image.pullPolicy` | Kubernetes image pull policy                             | `IfNotPresent`                |
 
 ### Gateway configurations

--- a/charts/gateway/values.yaml
+++ b/charts/gateway/values.yaml
@@ -17,7 +17,7 @@ gateway:
     ## @param gateway.image.repository Image in repository format (conduktor/conduktor-gateway)
     repository: conduktor/conduktor-gateway
     ## @param gateway.image.tag Image tag
-    tag: 3.2.2
+    tag: 3.3.0
     ## @param gateway.image.pullPolicy Kubernetes image pull policy
     pullPolicy: IfNotPresent
 


### PR DESCRIPTION
Updated Helm chart to use conduktor-gateway_3.3.0 instead of 3.2.2