### PR TITLE
fix: ServiceMonitor labels are now properly rendered and customizable

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,3 +1,12 @@
 #!/usr/bin/env bash
 
+set -eu
+
+echo "Lint charts"
+helm lint charts/gateway
+
+# set mandatory values
+helm lint charts/console --set config.organization.name=test,config.admin.email=test@test.io,config.admin.password=test,config.database.password=test,config.database.username=test,config.database.host=test
+
+echo "Update charts README"
 make generate-readme

--- a/charts/console/templates/console/servicemonitor.yaml
+++ b/charts/console/templates/console/servicemonitor.yaml
@@ -5,9 +5,14 @@ kind: ServiceMonitor
 metadata:
   name: {{ include "conduktor.platform.serviceMonitorName" . }}
   namespace: {{ default (include "common.names.namespace" .) .Values.platform.metrics.serviceMonitor.namespace | quote }}
-  {{- $labels := include "common.tplvalues.merge" (dict "values" .Values.platform.metrics.serviceMonitor.labels .Values.commonLabels "context" .) | fromYaml }}
-  labels: {{- include "common.labels.standard" ( dict "customLabels" $labels "context" $ ) | nindent 4 }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
     app.kubernetes.io/component: conduktor-platform
+    {{- if  .Values.platform.metrics.serviceMonitor.labels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.platform.metrics.serviceMonitor.labels "context" $ ) | nindent 4 }}
+    {{- end }}
   {{- if or .Values.platform.metrics.serviceMonitor.annotations .Values.commonAnnotations }}
   {{- $annotations := include "common.tplvalues.merge" (dict "values" .Values.platform.metrics.serviceMonitor.annotations .Values.commonAnnotations "context" .) | fromYaml }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $ ) | nindent 4 }}

--- a/charts/gateway/Chart.lock
+++ b/charts/gateway/Chart.lock
@@ -4,6 +4,6 @@ dependencies:
   version: 18.5.0
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 2.2.2
-digest: sha256:2702ad87423e3e97d19d9925b7147fbb34647ea2829cbb4713eefd6e5ea65aed
-generated: "2023-01-16T17:05:30.709571431+01:00"
+  version: 2.26.0
+digest: sha256:e7e579cac8b4c1b7ff1526c7c96276c7c6f1da2b999baf8e08f81b607d123f64
+generated: "2024-10-16T12:03:47.760017623+02:00"

--- a/charts/gateway/Chart.yaml
+++ b/charts/gateway/Chart.yaml
@@ -13,3 +13,5 @@ dependencies:
   - name: common
     version: 2.x.x
     repository: https://charts.bitnami.com/bitnami
+    tags:
+      - bitnami-common

--- a/charts/gateway/README.md
+++ b/charts/gateway/README.md
@@ -89,17 +89,21 @@ This section specify internal service configuration
 
 Gateway embed metrics to be installed within you cluster if your have the correct capabilities (Prometheus and Grafana operators).
 
-| Name                                     | Description                                                                   | Value        |
-| ---------------------------------------- | ----------------------------------------------------------------------------- | ------------ |
-| `metrics.alerts.enable`                  | Enable Prometheus alerts if Prometheus alerts rules is supported on cluster   | `false`      |
-| `metrics.checklyAlerts.enable`           | Enable alerts for checky jobs if Prometheus rules is supported on cluster     | `false`      |
-| `metrics.prometheus.enable`              | Enable ServiceMonitor Prometheus operator configuration for metrics scrapping | `false`      |
-| `metrics.prometheus.metricRelabelings`   | Configure metric relabeling in ServiceMonitor                                 | `{}`         |
-| `metrics.prometheus.relabelings`         | Configure relabelings in ServiceMonitor                                       | `{}`         |
-| `metrics.prometheus.extraParams`         | Extra parameters in ServiceMonitor                                            | `{}`         |
-| `metrics.grafana.enable`                 | Enable Grafana dashboards to installation                                     | `false`      |
-| `metrics.grafana.datasources.prometheus` | Prometheus datasource to use for metric dashboard                             | `prometheus` |
-| `metrics.grafana.datasources.loki`       | Loki datasource to use for log dashboard                                      | `loki`       |
+| Name                                     | Description                                                                      | Value                    |
+| ---------------------------------------- | -------------------------------------------------------------------------------- | ------------------------ |
+| `metrics.alerts.enable`                  | Enable Prometheus alerts if Prometheus alerts rules is supported on cluster      | `false`                  |
+| `metrics.checklyAlerts.enable`           | Enable alerts for checky jobs if Prometheus rules is supported on cluster        | `false`                  |
+| `metrics.prometheus.enable`              | Enable ServiceMonitor Prometheus operator configuration for metrics scrapping    | `false`                  |
+| `metrics.prometheus.annotations`         | Additional custom annotations for the ServiceMonitor                             | `{}`                     |
+| `metrics.prometheus.labels`              | Extra labels for the ServiceMonitor                                              | `{}`                     |
+| `metrics.prometheus.jobLabel`            | The name of the label on the target service to use as the job name in Prometheus | `app.kubernetes.io/name` |
+| `metrics.prometheus.metricRelabelings`   | Configure metric relabeling in ServiceMonitor                                    | `{}`                     |
+| `metrics.prometheus.relabelings`         | Configure relabelings in ServiceMonitor                                          | `{}`                     |
+| `metrics.prometheus.extraParams`         | Extra parameters in ServiceMonitor                                               | `{}`                     |
+| `metrics.grafana.enable`                 | Enable Grafana dashboards to installation                                        | `false`                  |
+| `metrics.grafana.labels`                 | Additional custom labels for Grafana dashboard ConfigMap                         | `{}`                     |
+| `metrics.grafana.datasources.prometheus` | Prometheus datasource to use for metric dashboard                                | `prometheus`             |
+| `metrics.grafana.datasources.loki`       | Loki datasource to use for log dashboard                                         | `loki`                   |
 
 ### Kubernetes common configuration
 
@@ -109,7 +113,7 @@ Shared Kubernetes configuration of the chart.
 | ----------------------- | -------------------------------------------------------------- | ------- |
 | `serviceAccount.create` | Create Kubernetes service account. Default kube value if false | `false` |
 | `serviceAccount.name`   | Service account name to attach to the Gateway deployment       | `""`    |
-| `commonLabels`          | Labels to be applied to all ressources created by this chart   | `{}`    |
+| `commonLabels`          | Labels to be applied to all resources created by this chart    | `{}`    |
 | `nodeSelector`          | Container node selector                                        | `{}`    |
 | `tolerations`           | Container tolerations                                          | `[]`    |
 | `affinity`              | Container affinity                                             | `{}`    |

--- a/charts/gateway/templates/grafana-dashboards.yaml
+++ b/charts/gateway/templates/grafana-dashboards.yaml
@@ -5,6 +5,9 @@ kind: ConfigMap
 metadata:
   name: {{ include "conduktor-gateway.fullname" . | trunc 52 }}-dashboards
   labels: {{ include "conduktor-gateway.labels" . | nindent 4 }}
+  {{- if .Values.metrics.grafana.labels }}
+  {{- include "common.tplvalues.render" ( dict "value" .Values.metrics.grafana.labels "context" $ ) | nindent 4 }}
+  {{- end }}
 data:
   gateway.json: |
 {{ .Files.Get "grafana-dashboards/gateway.json" | indent 4 }}

--- a/charts/gateway/templates/prometheus-monitoring.yaml
+++ b/charts/gateway/templates/prometheus-monitoring.yaml
@@ -4,8 +4,15 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ include "conduktor-gateway.fullname" . | trunc 52 }}-monitoring
+  labels: {{ include "conduktor-gateway.labels" . | nindent 4 }}
+    {{- if .Values.metrics.prometheus.labels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.metrics.prometheus.labels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if .Values.metrics.prometheus.annotations }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" .Values.metrics.prometheus.annotations "context" $ ) | nindent 4 }}
+  {{- end }}
 spec:
-  jobLabel: app.kubernetes.io/name
+  jobLabel: {{ .Values.metrics.prometheus.jobLabel | quote }}
   selector:
     matchLabels: {{ include "conduktor-gateway.labels" . | nindent 6 }}
       metrics.conduktor.io/prometheus: "true"

--- a/charts/gateway/values.yaml
+++ b/charts/gateway/values.yaml
@@ -155,6 +155,15 @@ metrics:
   prometheus:
     ## @param metrics.prometheus.enable Enable ServiceMonitor Prometheus operator configuration for metrics scrapping
     enable: false
+    ## @param metrics.prometheus.annotations Additional custom annotations for the ServiceMonitor
+    ##
+    annotations: { }
+    ## @param metrics.prometheus.labels Extra labels for the ServiceMonitor
+    ##
+    labels: { }
+    ## @param metrics.prometheus.jobLabel The name of the label on the target service to use as the job name in Prometheus
+    ##
+    jobLabel: "app.kubernetes.io/name"
     ## @param metrics.prometheus.metricRelabelings Configure metric relabeling in ServiceMonitor
     metricRelabelings: {}
     ## @param metrics.prometheus.relabelings Configure relabelings in ServiceMonitor
@@ -171,6 +180,9 @@ metrics:
   grafana:
     ## @param metrics.grafana.enable Enable Grafana dashboards to installation
     enable: false
+    ## @param  metrics.grafana.labels Additional custom labels for Grafana dashboard ConfigMap
+    ##
+    labels: { }
     datasources:
       ## @param metrics.grafana.datasources.prometheus Prometheus datasource to use for metric dashboard
       prometheus: prometheus
@@ -191,7 +203,7 @@ serviceAccount:
   ## @param serviceAccount.name Service account name to attach to the Gateway deployment
   name: ""
 
-## @param commonLabels Labels to be applied to all ressources created by this chart
+## @param commonLabels Labels to be applied to all resources created by this chart
 commonLabels: {}
 
 ## @param nodeSelector Container node selector

--- a/charts/gateway/values.yaml
+++ b/charts/gateway/values.yaml
@@ -157,10 +157,10 @@ metrics:
     enable: false
     ## @param metrics.prometheus.annotations Additional custom annotations for the ServiceMonitor
     ##
-    annotations: { }
+    annotations: {}
     ## @param metrics.prometheus.labels Extra labels for the ServiceMonitor
     ##
-    labels: { }
+    labels: {}
     ## @param metrics.prometheus.jobLabel The name of the label on the target service to use as the job name in Prometheus
     ##
     jobLabel: "app.kubernetes.io/name"
@@ -182,7 +182,7 @@ metrics:
     enable: false
     ## @param  metrics.grafana.labels Additional custom labels for Grafana dashboard ConfigMap
     ##
-    labels: { }
+    labels: {}
     datasources:
       ## @param metrics.grafana.datasources.prometheus Prometheus datasource to use for metric dashboard
       prometheus: prometheus


### PR DESCRIPTION
- Fix rendering of Console `ServiceMonitor` `labels`
- Add missing `labels` and `annotation` override on Gateway `ServiceMonitor`
- Add override for Gateway `ServiceMonitor` `jobLabel`
- Update Gateway `bitnami-common` dependency
- Add chart linting to pre-commit githook