### PR TITLE
Add clarity on using IRSA for S3

### DIFF
--- a/charts/console/values.yaml
+++ b/charts/console/values.yaml
@@ -139,7 +139,7 @@ monitoringConfig:
   ##
   ## NOTE: If set, corresponding secrets keys are ignored in monitoringConfig.storage
   ## The secret must contain the following keys:
-  ## CDK_MONITORING_STORAGE_S3_ACCESSKEYID and CDK_MONITORING_STORAGE_S3_SECRETACCESSKEY
+  ## CDK_MONITORING_STORAGE_S3_ACCESSKEYID and CDK_MONITORING_STORAGE_S3_SECRETACCESSKEY. To leverage IRSA leave these commented out in your S3 config
   ## or
   ## CDK_MONITORING_STORAGE_GCS_SERVICEACCOUNT
   ## or


### PR DESCRIPTION
Added a small comment to notify users that setting `CDK_MONITORING_STORAGE_S3_ACCESSKEYID and CDK_MONITORING_STORAGE_S3_SECRETACCESSKEY` will cause the storage.S3 values to be ignored.