### PR TITLE
fix: scheme added to deployments probes in gateway

### DIFF
--- a/charts/gateway/templates/deployment.yaml
+++ b/charts/gateway/templates/deployment.yaml
@@ -92,11 +92,13 @@ spec:
             httpGet:
               path: /health
               port: {{ .Values.gateway.admin.port }}
+              scheme: {{ .Values.tls.enable | ternary "HTTPS" "HTTP" }}
             periodSeconds: 5
           startupProbe:
             httpGet:
               path: /health
               port: {{ .Values.gateway.admin.port }}
+              scheme: {{ .Values.tls.enable | ternary "HTTPS" "HTTP" }}
             initialDelaySeconds: {{ .Values.gateway.startupProbeDelay | default 10 }}
           {{- with .Values.resources }}
           resources: {{- toYaml . | nindent 12 }}


### PR DESCRIPTION
Minor change to allow the usage of `https` for both `livenessProbe` and `startupProbe` of the gateway's deployment, if `tls` is enabled in the charts values.

Single line implementation using a [ternary](https://helm.sh/docs/chart_template_guide/function_list/#ternary) function - if condition is true it returns the first value, the second otherwise.