### PR TITLE
fix: console servicemonitor labels improved

### DIFF
--- a/charts/console/templates/console/servicemonitor.yaml
+++ b/charts/console/templates/console/servicemonitor.yaml
@@ -5,14 +5,9 @@ kind: ServiceMonitor
 metadata:
   name: {{ include "conduktor.platform.serviceMonitorName" . }}
   namespace: {{ default (include "common.names.namespace" .) .Values.platform.metrics.serviceMonitor.namespace | quote }}
-  labels: {{- include "common.labels.standard" . | nindent 4 }}
-    {{- if .Values.commonLabels }}
-    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
-    {{- end }}
+  {{- $labels := include "common.tplvalues.merge" ( dict "values" ( list .Values.platform.metrics.serviceMonitor.labels .Values.commonLabels ) "context" . ) }}
+  labels: {{- include "common.labels.standard" ( dict "customLabels" $labels "context" $ ) | nindent 4 }}
     app.kubernetes.io/component: conduktor-platform
-    {{- if  .Values.platform.metrics.serviceMonitor.labels }}
-    {{- include "common.tplvalues.render" ( dict "value" .Values.platform.metrics.serviceMonitor.labels "context" $ ) | nindent 4 }}
-    {{- end }}
   {{- if or .Values.platform.metrics.serviceMonitor.annotations .Values.commonAnnotations }}
   {{- $annotations := include "common.tplvalues.merge" (dict "values" .Values.platform.metrics.serviceMonitor.annotations .Values.commonAnnotations "context" .) | fromYaml }}
   annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $ ) | nindent 4 }}


### PR DESCRIPTION
Fix for labels' parse when the chart is referenced as a dependency or sub-chart (i.e. umbrella chart)

Resolves #128