### PR TITLE
console: Fix console admin secrets update

### DIFF
--- a/.github/ct-config.yaml
+++ b/.github/ct-config.yaml
@@ -16,3 +16,4 @@ chart-repos:
   - bitnami=https://charts.bitnami.com/bitnami
 namespace: ct
 release-label: test
+upgrade: true

--- a/charts/console/README.md
+++ b/charts/console/README.md
@@ -70,22 +70,22 @@ Refer to our [documentation](https://docs.conduktor.io/platform/configuration/en
 
 A list of Kafka clusters can be configured by adding them under the `config.clusters` key. See [Install with a Kafka cluster](#install-with-a-kafka-cluster) below. Alternatively, clusters can be added in the Console UI.
 
-| Name                                   | Description                                                                                                                                          | Value      |
-| -------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- | ---------- |
-| `config.organization.name`             | Your Conduktor Console Organization, you can only set it at install! You will need to change it in the Conduktor Console UI after the installation   | `""`       |
-| `config.admin.email`                   | Your Conduktor Console Admin email, you can only set it at install! You will need to change it in the Conduktor Console UI after the installation    | `""`       |
-| `config.admin.password`                | Your Conduktor Console Admin password, you can only set it at install! You will need to change it in the Conduktor Console UI after the installation | `""`       |
-| `config.database.host`                 | Your Conduktor Console Database host                                                                                                                 | `""`       |
-| `config.database.port`                 | Your Conduktor Console Database port                                                                                                                 | `5432`     |
-| `config.database.name`                 | Your Conduktor Console Database name                                                                                                                 | `postgres` |
-| `config.database.username`             | Your Conduktor Console Database username                                                                                                             | `""`       |
-| `config.database.password`             | Your Conduktor Console Database password                                                                                                             | `""`       |
-| `config.license`                       | Conduktor Console Enterprise license, if none given, the product will run in free tier                                                               | `""`       |
-| `config.existingLicenseSecret`         | Name of an existing secret containing the license                                                                                                    | `""`       |
-| `config.existingSecret`                | Name of an existing secret containing sensitive configuration                                                                                        | `""`       |
-| `config.platform.external.url`         | Force the platform to redirect and use this URL (useful when behind a proxy to fix SSO issues)                                                       | `""`       |
-| `config.platform.https.selfSigned`     | Enable HTTPS with a self-signed certificate (not recommended for production) based on 'config.platform.external.url' (required).                     | `false`    |
-| `config.platform.https.existingSecret` | Enable HTTPS with an existing secret containing the tls.crt and tls.key (required).                                                                  | `""`       |
+| Name                                   | Description                                                                                                                                     | Value       |
+| -------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
+| `config.organization.name`             | Your Conduktor Console Organization. Default is `Conduktor` if not set.                                                                         | `Conduktor` |
+| `config.admin.email`                   | Your Conduktor Console Admin email. If changed a new admin user will be created with this email and previous admin user will still be available | `""`        |
+| `config.admin.password`                | Your Conduktor Console Admin password. If change current admin user password will be updated.                                                   | `""`        |
+| `config.database.host`                 | Your Conduktor Console Database host                                                                                                            | `""`        |
+| `config.database.port`                 | Your Conduktor Console Database port                                                                                                            | `5432`      |
+| `config.database.name`                 | Your Conduktor Console Database name                                                                                                            | `postgres`  |
+| `config.database.username`             | Your Conduktor Console Database username                                                                                                        | `""`        |
+| `config.database.password`             | Your Conduktor Console Database password                                                                                                        | `""`        |
+| `config.license`                       | Conduktor Console Enterprise license, if none given, the product will run in free tier                                                          | `""`        |
+| `config.existingLicenseSecret`         | Name of an existing secret containing the license                                                                                               | `""`        |
+| `config.existingSecret`                | Name of an existing secret containing sensitive configuration                                                                                   | `""`        |
+| `config.platform.external.url`         | Force the platform to redirect and use this URL (useful when behind a proxy to fix SSO issues)                                                  | `""`        |
+| `config.platform.https.selfSigned`     | Enable HTTPS with a self-signed certificate (not recommended for production) based on 'config.platform.external.url' (required).                | `false`     |
+| `config.platform.https.existingSecret` | Enable HTTPS with an existing secret containing the tls.crt and tls.key (required).                                                             | `""`        |
 
 ### Platform Monitoring product Parameters
 

--- a/charts/console/templates/console/secret-credentials.yaml
+++ b/charts/console/templates/console/secret-credentials.yaml
@@ -15,12 +15,9 @@ metadata:
   {{- end }}
 type: Opaque
 data:
-  {{- $orgaName := required "config.organization.name MUST be set in values" .Values.config.organization.name  }}
-  CDK_ORGANIZATION_NAME: {{ include "common.secrets.lookup" (dict "secret" $secretName "key" "CDK_ORGANIZATION_NAME" "defaultValue" $orgaName "context" $) }}
-  {{- $adminEmail := required "config.admin.email and config.admin.password MUST be set in values" .Values.config.admin.email  }}
-  CDK_ADMIN_EMAIL: {{ include "common.secrets.lookup" (dict "secret" $secretName "key" "CDK_ADMIN_EMAIL" "defaultValue" $adminEmail "context" $) }}
-  {{ $adminPassword := required "config.admin.email and config.admin.password MUST be set in values" .Values.config.admin.password }}
-  CDK_ADMIN_PASSWORD: {{ include "common.secrets.lookup" (dict "secret" $secretName "key" "CDK_ADMIN_PASSWORD" "defaultValue" $adminPassword "context" $) }}
+  CDK_ORGANIZATION_NAME: {{ .Values.config.organization.name | default "Conduktor" | b64enc }}
+  CDK_ADMIN_EMAIL: {{ required "config.admin.email and config.admin.password MUST be set in values" .Values.config.admin.email | b64enc }}
+  CDK_ADMIN_PASSWORD: {{ required "config.admin.email and config.admin.password MUST be set in values" .Values.config.admin.password | b64enc }}
   CDK_DATABASE_PASSWORD: {{ required "config.database.password MUST be set in values" .Values.config.database.password | b64enc }}
   CDK_DATABASE_USERNAME: {{ required "config.database.username MUST be set in values" .Values.config.database.username | b64enc }}
 {{- end }}

--- a/charts/console/values.yaml
+++ b/charts/console/values.yaml
@@ -68,21 +68,26 @@ diagnosticMode:
 ## @descriptionEnd
 
 config:
-  ## @param config.organization.name Your Conduktor Console Organization, you can only set it at install! You will need to change it in the Conduktor Console UI after the installation
+  ## @param config.organization.name Your Conduktor Console Organization. Default is `Conduktor` if not set.
+  ## Could be provided via an existing secret with `config.existingSecret` using the key `CDK_ORGANIZATION_NAME`.
   organization:
-    name: ""
+    name: "Conduktor"
 
   admin:
-    ## @param config.admin.email Your Conduktor Console Admin email, you can only set it at install! You will need to change it in the Conduktor Console UI after the installation
+    ## @param config.admin.email Your Conduktor Console Admin email. If changed a new admin user will be created with this email and previous admin user will still be available
+    ## Could be provided via an existing secret with `config.existingSecret` using the key `CDK_ADMIN_EMAIL`.
     email: ""
-    ## @param config.admin.password Your Conduktor Console Admin password, you can only set it at install! You will need to change it in the Conduktor Console UI after the installation
+    ## @param config.admin.password Your Conduktor Console Admin password. If change current admin user password will be updated.
+    ## Could be provided via an existing secret with `config.existingSecret` using the key `CDK_ADMIN_PASSWORD`.
     password: ""
 
   ## @param config.database.host Your Conduktor Console Database host
   ## @param config.database.port Your Conduktor Console Database port
   ## @param config.database.name Your Conduktor Console Database name
   ## @param config.database.username Your Conduktor Console Database username
+  ## Could be provided via an existing secret with `config.existingSecret` using the key `CDK_DATABASE_PASSWORD`.
   ## @param config.database.password Your Conduktor Console Database password
+  ## Could be provided via an existing secret with `config.existingSecret` using the key `CDK_DATABASE_USERNAME`.
   database:
     host: ""
     port: 5432


### PR DESCRIPTION
- Allow update of admin login and password when using default secrets by remove unnecessary `lookup` (fix #138) 
- Make organization name optional, with default to `Conduktor`
- Enable upgrade from previous release chart tests