### PR TITLE
add new configs for aggregated and non aggregated metrics

### DIFF
--- a/charts/console/templates/_helpers.tpl
+++ b/charts/console/templates/_helpers.tpl
@@ -328,7 +328,7 @@ Return platform monitoring enable non aggregated metrics collection. Default to 
 {{- define "conduktor.monitoring.enableNonAggregatedMetrics" -}}
 {{- $enable := "true" -}}
 {{- if .Values.config.monitoring -}}
-{{- $enable := (default $use (index .Values "config" "monitoring" "enable-non-aggregated-metrics")) }}
+{{- $enable := (default $enable (index .Values "config" "monitoring" "enable-non-aggregated-metrics")) }}
 {{- end -}}
 {{- printf "%s" $enable -}}
 {{- end -}}

--- a/charts/console/templates/_helpers.tpl
+++ b/charts/console/templates/_helpers.tpl
@@ -312,6 +312,28 @@ Return platform monitoring api poll rate for clusters. Default to 60s
 {{- end -}}
 
 {{/*
+Return platform monitoring use aggregated metrics for graph. Default to false
+*/}}
+{{- define "conduktor.monitoring.useAggregatedMetrics" -}}
+{{- $use := "false" -}}
+{{- if .Values.config.monitoring -}}
+{{- $use := (default $use (index .Values "config" "monitoring" "use-aggregated-metrics")) }}
+{{- end -}}
+{{- printf "%s" $use -}}
+{{- end -}}
+
+{{/*
+Return platform monitoring enable non aggregated metrics collection. Default to true
+*/}}
+{{- define "conduktor.monitoring.enableNonAggregatedMetrics" -}}
+{{- $enable := "true" -}}
+{{- if .Values.config.monitoring -}}
+{{- $enable := (default $use (index .Values "config" "monitoring" "enable-non-aggregated-metrics")) }}
+{{- end -}}
+{{- printf "%s" $enable -}}
+{{- end -}}
+
+{{/*
 Return platform monitoring cortex url. Like http(s)://cortex.nsp.svc.cluster.local:9009/
 */}}
 {{- define "conduktor.monitoring.cortexUrl" -}}

--- a/charts/console/templates/console/deployment.yaml
+++ b/charts/console/templates/console/deployment.yaml
@@ -131,6 +131,10 @@ spec:
             {{- if .Values.platformCortex.enabled }}
             - name: CDK_MONITORING_CLUSTERS-REFRESH-INTERVAL
               value: {{ include "conduktor.monitoring.clustersRefreshInterval" . | quote }}
+            - name: CDK_MONITORING_USE-AGGREGATED-METRICS
+              value: {{ include "conduktor.monitoring.useAggregatedMetrics" . | quote }}
+            - name: CDK_MONITORING_ENABLE-NON-AGGREGATED-METRICS
+              value: {{ include "conduktor.monitoring.enableNonAggregatedMetrics" . | quote }}
             - name: CDK_MONITORING_CORTEX-URL
               value: {{ include "conduktor.monitoring.cortexUrl" . | quote }}
             - name: CDK_MONITORING_ALERT-MANAGER-URL


### PR DESCRIPTION
This update introduces the two new configuration keys for non-aggregated metrics:

1. **`use_aggregated_metrics`** (default: **disabled**)  
   - Controls whether the frontend should use aggregated metrics.  
   - Currently **disabled** by default.  
   - This option will be **removed in 2-3 months** after a few releases, giving customers time to start collecting aggregated metrics before switching.  

2. **`enable_non_aggregated_metrics`** (default: **enabled**)  
   - Determines whether non-aggregated metrics should be collected.  
   - For now, it is **enabled** by default.  
   - In the future, it will be **disabled** by default. Customers who still require non-aggregated metrics will need to explicitly enable it within their infrastructure. 