### PR TITLE
[Gateway] Add support for extraDeploy on Gateway chart

### DIFF
--- a/charts/gateway/README.md
+++ b/charts/gateway/README.md
@@ -27,14 +27,15 @@ Current available global Docker image parameters: imageRegistry, imagePullSecret
 
 ### Common parameters
 
-| Name                | Description                                     | Value           |
-| ------------------- | ----------------------------------------------- | --------------- |
-| `nameOverride`      | String to partially override common.names.name  | `""`            |
-| `fullnameOverride`  | String to fully override common.names.fullname  | `""`            |
-| `namespaceOverride` | String to fully override common.names.namespace | `""`            |
-| `commonLabels`      | Labels to add to all deployed objects           | `{}`            |
-| `commonAnnotations` | Annotations to add to all deployed objects      | `{}`            |
-| `clusterDomain`     | Kubernetes cluster domain name                  | `cluster.local` |
+| Name                | Description                                       | Value           |
+| ------------------- | ------------------------------------------------- | --------------- |
+| `nameOverride`      | String to partially override common.names.name    | `""`            |
+| `fullnameOverride`  | String to fully override common.names.fullname    | `""`            |
+| `namespaceOverride` | String to fully override common.names.namespace   | `""`            |
+| `commonLabels`      | Labels to add to all deployed objects             | `{}`            |
+| `commonAnnotations` | Annotations to add to all deployed objects        | `{}`            |
+| `clusterDomain`     | Kubernetes cluster domain name                    | `cluster.local` |
+| `extraDeploy`       | Array of extra objects to deploy with the release | `[]`            |
 
 ### Gateway image configuration
 
@@ -484,3 +485,18 @@ If you want to import dashboards manually, you can use the exported json files f
 > [!NOTE]  
 > Grafana Dashboard exported json files expect to have a datasource named `prometheus` and `loki` to be available in Grafana and that Conduktor Gateway run inside Kubernetes with `pod` label on metrics.
 > Dashboards are tested with Grafana **9.x** and **10.x**.
+
+
+### Extra resource to deploy
+
+You can deploy extra resources with the Gateway deployment by adding them to the `extraDeploy` field in the `values.yaml` file.
+
+```yaml
+extraDeploy:
+  - apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: extra-configmap
+    data:
+      some-key: some-value
+```

--- a/charts/gateway/templates/extra-deploy.yaml
+++ b/charts/gateway/templates/extra-deploy.yaml
@@ -1,0 +1,4 @@
+{{- range .Values.extraDeploy }}
+---
+{{ include "common.tplvalues.render" (dict "value" . "context" $) }}
+{{- end }}

--- a/charts/gateway/values.yaml
+++ b/charts/gateway/values.yaml
@@ -33,6 +33,9 @@ commonAnnotations: {}
 ## @param clusterDomain Kubernetes cluster domain name
 ##
 clusterDomain: cluster.local
+## @param extraDeploy Array of extra objects to deploy with the release
+##
+extraDeploy: []
 
 gateway:
   ## @section Gateway image configuration


### PR DESCRIPTION
Add support of `extraDeploy` resources to deploy alongside Gateway chart

```yaml
extraDeploy:
  - apiVersion: v1
    kind: ConfigMap
    metadata:
      name: extra-configmap
    data:
      some-key: some-value
```