### PR TITLE
Added Service specific labels to Gateway Chart

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -107,6 +107,8 @@ install-dev-deps:  ## Install development dependencies (PostgreSQL, Minio, monit
 	@echo "	Internal : grafana-service.${MONITORING_NAMESPACE}.svc.cluster.local:3000"
 	@echo "	Access Grafana with : $ kubectl port-forward svc/grafana-service -n ${MONITORING_NAMESPACE} 3000:3000"
 	@echo "	Credentials : admin/admin"
+	@echo "Kafka:"
+	@echo "	Internal : kafka-local-dev.${NAMESPACE}.svc.cluster.local:9092"
 
 # Extended targets
 ##################

--- a/charts/gateway/README.md
+++ b/charts/gateway/README.md
@@ -113,7 +113,7 @@ This section specifies external service configuration
 | `service.external.type`        | Type of load balancer                               | `ClusterIP` |
 | `service.external.ip`          | IP to configure                                     | `""`        |
 | `service.external.annotations` |                                                     | `{}`        |
-| `service.external.labels`      |                                                     | `{}`        |
+| `service.external.labels`      | Labels to be added to Gateway internal service      | `{}`        |
 | `service.external.admin`       | Enable admin exposition on external service         | `false`     |
 | `service.external.jmx`         | Enable jmx exposition on external service           | `false`     |
 
@@ -121,10 +121,10 @@ This section specifies external service configuration
 
 This section specify internal service configuration
 
-| Name                           | Description | Value |
-| ------------------------------ | ----------- | ----- |
-| `service.internal.annotations` |             | `{}`  |
-| `service.internal.labels`      |             | `{}`  |
+| Name                           | Description                                    | Value |
+| ------------------------------ | ---------------------------------------------- | ----- |
+| `service.internal.annotations` |                                                | `{}`  |
+| `service.internal.labels`      | Labels to be added to Gateway internal service | `{}`  |
 
 ### Gateway ingress configurations
 

--- a/charts/gateway/README.md
+++ b/charts/gateway/README.md
@@ -113,6 +113,7 @@ This section specifies external service configuration
 | `service.external.type`        | Type of load balancer                               | `ClusterIP` |
 | `service.external.ip`          | IP to configure                                     | `""`        |
 | `service.external.annotations` |                                                     | `{}`        |
+| `service.external.labels`      |                                                     | `{}`        |
 | `service.external.admin`       | Enable admin exposition on external service         | `false`     |
 | `service.external.jmx`         | Enable jmx exposition on external service           | `false`     |
 
@@ -123,6 +124,7 @@ This section specify internal service configuration
 | Name                           | Description | Value |
 | ------------------------------ | ----------- | ----- |
 | `service.internal.annotations` |             | `{}`  |
+| `service.internal.labels`      |             | `{}`  |
 
 ### Gateway ingress configurations
 

--- a/charts/gateway/templates/service-external.yaml
+++ b/charts/gateway/templates/service-external.yaml
@@ -5,23 +5,20 @@ metadata:
   name:  {{ include "conduktor-gateway.externalServiceName" . }}
   namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{ include "common.labels.standard" . | nindent 4 }}
-    app.kubernetes.io/component: conduktor-platform
-    {{- if .Values.service.external.labels }}
-    {{- include "common.tplvalues.render" ( dict "value" .Values.service.external.labels "context" $) | nindent 4 }}
+    app.kubernetes.io/component: conduktor-gateway
+    {{- with .Values.service.external.labels }}
+    {{- include "common.tplvalues.render" ( dict "value" . "context" $) | nindent 4 }}
     {{- end }}
-    {{- if .Values.commonLabels }}
-    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
-    {{- end }}
-    {{- if .Values.metrics.prometheus.enable }}
-    metrics.conduktor.io/prometheus: {{ .Values.metrics.prometheus.enable | quote }}
+    {{- with .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" . "context" $ ) | nindent 4 }}
     {{- end }}
   {{- if or .Values.service.external.annotations .Values.commonAnnotations }}
   annotations:
-    {{- if .Values.service.external.annotations }}
-    {{- include "common.tplvalues.render" ( dict "value" .Values.service.external.annotations "context" $) | nindent 4 }}
+    {{- with .Values.service.external.annotations }}
+    {{- include "common.tplvalues.render" ( dict "value" . "context" $) | nindent 4 }}
     {{- end }}
-    {{- if .Values.commonAnnotations }}
-    {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+    {{- with .Values.commonAnnotations }}
+    {{- include "common.tplvalues.render" ( dict "value" . "context" $ ) | nindent 4 }}
     {{- end }}
   {{- end }}
 spec:

--- a/charts/gateway/templates/service-external.yaml
+++ b/charts/gateway/templates/service-external.yaml
@@ -3,9 +3,26 @@ apiVersion: v1
 kind: Service
 metadata:
   name:  {{ include "conduktor-gateway.externalServiceName" . }}
-  labels: {{ include "conduktor-gateway.labels" . | nindent 4 }}
-  {{- with .Values.service.external.annotations }}
-  annotations: {{ toYaml . | nindent 4 }}
+  namespace: {{ include "common.names.namespace" . | quote }}
+  labels: {{ include "common.labels.standard" . | nindent 4 }}
+    app.kubernetes.io/component: conduktor-platform
+    {{- if .Values.service.external.labels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.service.external.labels "context" $) | nindent 4 }}
+    {{- end }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+    {{- if .Values.metrics.prometheus.enable }}
+    metrics.conduktor.io/prometheus: {{ .Values.metrics.prometheus.enable | quote }}
+    {{- end }}
+  {{- if or .Values.service.external.annotations .Values.commonAnnotations }}
+  annotations:
+    {{- if .Values.service.external.annotations }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.service.external.annotations "context" $) | nindent 4 }}
+    {{- end }}
+    {{- if .Values.commonAnnotations }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+    {{- end }}
   {{- end }}
 spec:
   type: {{ .Values.service.external.type }}

--- a/charts/gateway/templates/service-internal.yaml
+++ b/charts/gateway/templates/service-internal.yaml
@@ -2,10 +2,26 @@ apiVersion: v1
 kind: Service
 metadata:
   name:  {{ include "conduktor-gateway.internalServiceName" . }}
-  labels: {{ include "conduktor-gateway.labels" . | nindent 4 }}
+  namespace: {{ include "common.names.namespace" . | quote }}
+  labels: {{ include "common.labels.standard" . | nindent 4 }}
+    app.kubernetes.io/component: conduktor-platform
+    {{- if .Values.service.internal.labels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.service.internal.labels "context" $) | nindent 4 }}
+    {{- end }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+    {{- if .Values.metrics.prometheus.enable }}
     metrics.conduktor.io/prometheus: {{ .Values.metrics.prometheus.enable | quote }}
-  {{- with .Values.service.internal.annotations }}
-  annotations: {{ toYaml . | nindent 4 }}
+    {{- end }}
+  {{- if or .Values.service.internal.annotations .Values.commonAnnotations }}
+  annotations:
+    {{- if .Values.service.internal.annotations }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.service.internal.annotations "context" $) | nindent 4 }}
+    {{- end }}
+    {{- if .Values.commonAnnotations }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+    {{- end }}
   {{- end }}
 spec:
   type: ClusterIP

--- a/charts/gateway/templates/service-internal.yaml
+++ b/charts/gateway/templates/service-internal.yaml
@@ -4,23 +4,20 @@ metadata:
   name:  {{ include "conduktor-gateway.internalServiceName" . }}
   namespace: {{ include "common.names.namespace" . | quote }}
   labels: {{ include "common.labels.standard" . | nindent 4 }}
-    app.kubernetes.io/component: conduktor-platform
-    {{- if .Values.service.internal.labels }}
-    {{- include "common.tplvalues.render" ( dict "value" .Values.service.internal.labels "context" $) | nindent 4 }}
+    app.kubernetes.io/component: conduktor-gateway
+    {{- with .Values.service.internal.labels }}
+    {{- include "common.tplvalues.render" ( dict "value" . "context" $) | nindent 4 }}
     {{- end }}
-    {{- if .Values.commonLabels }}
-    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
-    {{- end }}
-    {{- if .Values.metrics.prometheus.enable }}
-    metrics.conduktor.io/prometheus: {{ .Values.metrics.prometheus.enable | quote }}
+    {{- with .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" . "context" $ ) | nindent 4 }}
     {{- end }}
   {{- if or .Values.service.internal.annotations .Values.commonAnnotations }}
   annotations:
-    {{- if .Values.service.internal.annotations }}
-    {{- include "common.tplvalues.render" ( dict "value" .Values.service.internal.annotations "context" $) | nindent 4 }}
+    {{- with .Values.service.internal.annotations }}
+    {{- include "common.tplvalues.render" ( dict "value" . "context" $) | nindent 4 }}
     {{- end }}
-    {{- if .Values.commonAnnotations }}
-    {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+    {{- with .Values.commonAnnotations }}
+    {{- include "common.tplvalues.render" ( dict "value" . "context" $ ) | nindent 4 }}
     {{- end }}
   {{- end }}
 spec:

--- a/charts/gateway/templates/service-internal.yaml
+++ b/charts/gateway/templates/service-internal.yaml
@@ -11,6 +11,9 @@ metadata:
     {{- with .Values.commonLabels }}
     {{- include "common.tplvalues.render" ( dict "value" . "context" $ ) | nindent 4 }}
     {{- end }}
+    {{- if .Values.metrics.prometheus.enable }}
+    metrics.conduktor.io/prometheus: {{ .Values.metrics.prometheus.enable | quote }}
+    {{- end }}
   {{- if or .Values.service.internal.annotations .Values.commonAnnotations }}
   annotations:
     {{- with .Values.service.internal.annotations }}

--- a/charts/gateway/values.yaml
+++ b/charts/gateway/values.yaml
@@ -202,6 +202,8 @@ service:
     ip: ""
     ## @param service.external.annotations
     annotations: {}
+    ## @param service.external.labels
+    labels: {}
     # LoadBalancer externaldns gke support by annotation https://github.com/kubernetes-sigs/external-dns/blob/master/docs/tutorials/gke.md#verify-using-an-external-load-balancer
     # external-dns.alpha.kubernetes.io/hostname: "{{ required "A valid .Values.gateway.domain is required!" .Values.gateway.domain }}"
     ## @param service.external.admin Enable admin exposition on external service
@@ -215,6 +217,8 @@ service:
   internal:
     ## @param service.internal.annotations
     annotations: {}
+    ## @param service.internal.labels
+    labels: {}
 
 ## @section Gateway ingress configurations
 ## @descriptionStart

--- a/charts/gateway/values.yaml
+++ b/charts/gateway/values.yaml
@@ -202,7 +202,7 @@ service:
     ip: ""
     ## @param service.external.annotations
     annotations: {}
-    ## @param service.external.labels
+    ## @param service.external.labels Labels to be added to Gateway internal service
     labels: {}
     # LoadBalancer externaldns gke support by annotation https://github.com/kubernetes-sigs/external-dns/blob/master/docs/tutorials/gke.md#verify-using-an-external-load-balancer
     # external-dns.alpha.kubernetes.io/hostname: "{{ required "A valid .Values.gateway.domain is required!" .Values.gateway.domain }}"
@@ -217,7 +217,7 @@ service:
   internal:
     ## @param service.internal.annotations
     annotations: {}
-    ## @param service.internal.labels
+    ## @param service.internal.labels Labels to be added to Gateway internal service
     labels: {}
 
 ## @section Gateway ingress configurations


### PR DESCRIPTION
Refactored the GW annotations to include all commonAnnotations as well as service annotations. Added the ability to set service specific labels.
External Example:
![image](https://github.com/user-attachments/assets/f8fe72a9-1ad0-4fe7-9171-1f2cf8c507c7)

Internal Example:
![image](https://github.com/user-attachments/assets/5a710651-95c0-4aaf-999e-c045cdc99117)
