### PR TITLE
fix(Gateway): fix duplicate GATEWAY_SECURED_METRICS env

### DIFF
--- a/charts/gateway/Chart.yaml
+++ b/charts/gateway/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "3.7.0"
 description: Conduktor Gateway chart
 name: conduktor-gateway
-version: 3.7.0
+version: 3.7.1
 dependencies:
   - name: common
     version: 2.x.x

--- a/charts/gateway/Chart.yaml
+++ b/charts/gateway/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "3.7.0"
 description: Conduktor Gateway chart
 name: conduktor-gateway
-version: 3.7.1
+version: 3.7.0
 dependencies:
   - name: common
     version: 2.x.x

--- a/charts/gateway/templates/_helpers.tpl
+++ b/charts/gateway/templates/_helpers.tpl
@@ -146,7 +146,7 @@ Get the first admin user from the list of users
 
 {{/*
 Check if env exist in context
-
+Usage : include "conduktor-gateway.envExists" (dict "envkey" "ENV_VAR_NAME" "context" $)
 Params:
   - envKey - String - Required - Name of the env.
   - context - Context - Required - Parent context.

--- a/charts/gateway/templates/deployment.yaml
+++ b/charts/gateway/templates/deployment.yaml
@@ -54,8 +54,10 @@ spec:
             - name: JAVA_TOOL_OPTIONS
               value: {{ tpl .Values.gateway.jmx.jvmArgs . | quote }}
             {{- end}}
+            {{- if eq (include "conduktor-gateway.envExists" (dict "envkey" "GATEWAY_SECURED_METRICS" "context" $)) "false" }}
             - name: GATEWAY_SECURED_METRICS
               value: {{ .Values.gateway.admin.securedMetrics | quote }}
+            {{- end}}
             {{- if and .Values.gateway.userPool .Values.gateway.userPool.serviceAccountRequired }}
             - name: GATEWAY_USER_POOL_SERVICE_ACCOUNT_REQUIRED
               value: {{ .Values.gateway.userPool.serviceAccountRequired | quote }}


### PR DESCRIPTION
Prevent duplicate `GATEWAY_SECURED_METRICS` in pod env if it is also set in `gateway.env` or `gateway.extraSecretEnvVars`.