### PR TITLE
Better root readme version badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,15 +16,23 @@
     <a href="https://github.com/conduktor/conduktor-public-charts/issues">Request Feature</a>
     ·
     <a href="https://support.conduktor.io/">Contact support</a>
+    <br /><br />
+    <img alt="License" src="https://img.shields.io/github/license/conduktor/conduktor-public-charts?label=Charts%20license&color=BCFE68">
+    <br /><br />
+    <a href="https://github.com/conduktor/conduktor-public-charts/releases">
+        <img alt="Console Chart Version" src="https://img.shields.io/badge/dynamic/yaml?url=https%3A%2F%2Fraw.githubusercontent.com%2Fconduktor%2Fconduktor-public-charts%2Frefs%2Fheads%2Fmain%2Fcharts%2Fconsole%2FChart.yaml&query=%24.version&prefix=conduktor-console:&logo=helm&label=Console%20Chart&color=BCFE68&">
+    </a> /
+    <a href="https://hub.docker.com/r/conduktor/conduktor-console">
+        <img alt="Console Application Version" src="https://img.shields.io/badge/dynamic/yaml?url=https%3A%2F%2Fraw.githubusercontent.com%2Fconduktor%2Fconduktor-public-charts%2Frefs%2Fheads%2Fmain%2Fcharts%2Fconsole%2FChart.yaml&query=%24.appVersion&prefix=conduktor%2Fconduktor-console%3A&logo=docker&label=Console%20Application&color=BCFE68">
+    </a>
     <br />
-    <br />
-    <a href="https://github.com/conduktor/conduktor-public-charts/releases"><img alt="Gateway Release" src="https://img.shields.io/github/v/release/conduktor/conduktor-public-charts?sort=date&filter=conduktor-gateway*&logo=github&label=Gateway%20Release&color=BCFE68"></a>
-    ·
-    <a href="https://github.com/conduktor/conduktor-public-charts/releases"><img alt="Console Release" src="https://img.shields.io/github/v/release/conduktor/conduktor-public-charts?sort=date&filter=Console*&logo=github&label=Console%20Release&color=BCFE68"></a>
-    ·
-    <img alt="License" src="https://img.shields.io/github/license/conduktor/conduktor-public-charts?color=BCFE68">
-    <br />
-    <br />
+    <a href="https://github.com/conduktor/conduktor-public-charts/releases">
+        <img alt="Gateway Chart Version" src="https://img.shields.io/badge/dynamic/yaml?url=https%3A%2F%2Fraw.githubusercontent.com%2Fconduktor%2Fconduktor-public-charts%2Frefs%2Fheads%2Fmain%2Fcharts%2Fgateway%2FChart.yaml&query=%24.version&prefix=conduktor-gateway:&logo=helm&label=Gateway%20Chart&color=BCFE68&">
+    </a>  /
+    <a href="https://hub.docker.com/r/conduktor/conduktor-gateway">
+        <img alt="Gateway Application Version" src="https://img.shields.io/badge/dynamic/yaml?url=https%3A%2F%2Fraw.githubusercontent.com%2Fconduktor%2Fconduktor-public-charts%2Frefs%2Fheads%2Fmain%2Fcharts%2Fgateway%2FChart.yaml&query=%24.appVersion&prefix=conduktor%2Fconduktor-gateway%3A&logo=docker&label=Gateway%20Application&color=BCFE68">
+    </a>
+    <br /><br />
     <a href="https://conduktor.io/"><img src="https://img.shields.io/badge/Website-conduktor.io-192A4E?color=BCFE68" alt="Scale Data Streaming With Security and Control"></a>
     ·
     <a href="https://twitter.com/getconduktor"><img alt="X (formerly Twitter) Follow" src="https://img.shields.io/twitter/follow/getconduktor?color=BCFE68"></a>


### PR DESCRIPTION
Change from 
![image](https://github.com/user-attachments/assets/25e75f78-5811-497f-9194-1a1830883a46)
to
![image](https://github.com/user-attachments/assets/00c900ea-4ae6-4f64-bd34-85b4777525b9)

To make it clearer the chart and applications versions