### PR TITLE
Improve Console ingress TLS configuration and test / document with snippets all cases.

### DIFF
--- a/.github/ct-config.yaml
+++ b/.github/ct-config.yaml
@@ -16,4 +16,4 @@ chart-repos:
   - bitnami=https://charts.bitnami.com/bitnami
 namespace: ct
 release-label: test
-upgrade: false
+upgrade: true

--- a/.github/ct-config.yaml
+++ b/.github/ct-config.yaml
@@ -16,4 +16,4 @@ chart-repos:
   - bitnami=https://charts.bitnami.com/bitnami
 namespace: ct
 release-label: test
-upgrade: true
+upgrade: false

--- a/charts/console/README.md
+++ b/charts/console/README.md
@@ -33,41 +33,18 @@ Helm Chart to deploy Conduktor Console on Kubernetes.
 - Kubernetes 1.19+
 - Helm 3.2.0+
 
-  - [Parameters](#parameters)
-    - [Global parameters](#global-parameters)
-    - [Common parameters](#common-parameters)
-    - [Platform product Parameters](#platform-product-parameters)
-    - [Platform Monitoring product Parameters](#platform-monitoring-product-parameters)
-    - [Platform Deployment Parameters](#platform-deployment-parameters)
-    - [Platform Metrics activation](#platform-metrics-activation)
-    - [Traffic Exposure Parameters](#traffic-exposure-parameters)
-    - [Other Parameters](#other-parameters)
-    - [Platform Cortex Parameters](#platform-cortex-parameters)
-  - [Snippets](#snippets)
-    - [Console configuration](#console-configuration)
-    - [Kubernetes configuration](#kubernetes-configuration)
-    - [Install with an enterprise license](#install-with-an-enterprise-license)
-    - [Install with a basic SSO configuration](#install-with-a-basic-sso-configuration)
-    - [Install with a Kafka cluster](#install-with-a-kafka-cluster)
-    - [Install with a Confluent Cloud cluster](#install-with-a-confluent-cloud-cluster)
-    - [Install without Conduktor monitoring](#install-without-conduktor-monitoring)
-    - [Provide the license as a Kubernetes Secret](#provide-the-license-as-a-kubernetes-secret)
-    - [Provide credentials configuration as a Kubernetes Secret](#provide-credentials-configuration-as-a-kubernetes-secret)
-    - [Provide monitoring configuration as a Kubernetes Secret](#provide-monitoring-configuration-as-a-kubernetes-secret)
-    - [Pulling from private registry using `global.imagePullSecrets`](#pulling-from-private-registry-using-globalimagepullsecrets)
-    - [Store platform data into a Persistent Volume](#store-platform-data-into-a-persistent-volume)
-    - [Install with a PodAffinity](#install-with-a-podaffinity)
-    - [Provide console configuration as a Kubernetes ConfigMap](#provide-console-configuration-as-a-kubernetes-configmap)
-    - [Provide additional credentials as a Kubernetes Secret](#provide-additional-credentials-as-a-kubernetes-secret)
-    - [Install with a toleration](#install-with-a-toleration)
-    - [Install with Self-Signed TLS certificate](#install-with-self-signed-tls-certificate)
-    - [Install with a custom TLS certificate on the platform Pod](#install-with-a-custom-tls-certificate-on-the-platform-pod)
-    - [Install with a custom service account](#install-with-a-custom-service-account)
-    - [Install with a AWS EKS IAM Role](#install-with-a-aws-eks-iam-role)
-    - [Install with Console technical monitoring](#install-with-console-technical-monitoring)
-    - [Install with custom certificates or keytab](#install-with-custom-certificates-or-keytab)
-  - [Troubleshooting](#troubleshooting)
-
+* [Parameters](#parameters)
+  * [Global parameters](#global-parameters)
+  * [Common parameters](#common-parameters)
+  * [Platform product Parameters](#platform-product-parameters)
+  * [Platform Monitoring product Parameters](#platform-monitoring-product-parameters)
+  * [Platform Deployment Parameters](#platform-deployment-parameters)
+  * [Platform Metrics activation](#platform-metrics-activation)
+  * [Traffic Exposure Parameters](#traffic-exposure-parameters)
+  * [Other Parameters](#other-parameters)
+  * [Platform Cortex Parameters](#platform-cortex-parameters)
+* [Snippets](#snippets)
+* [Troubleshooting](#troubleshooting)
 
 ## Parameters
 
@@ -285,7 +262,7 @@ Console expose metrics that could be collected and presented if your environment
 | `ingress.extraHosts`               | An array with additional hostname(s) to be covered with the ingress record                                                       | `[]`                     |
 | `ingress.extraPaths`               | An array with additional arbitrary paths that may need to be added to the ingress under the main host                            | `[]`                     |
 | `ingress.extraTls`                 | TLS configuration for additional hostname(s) to be covered with this ingress record                                              | `[]`                     |
-| `ingress.secrets`                  | Custom TLS certificates as secrets                                                                                               | `[]`                     |
+| `ingress.secrets`                  | Existing TLS secrets or custom TLS certificates/keys secrets to create and use                                                   | `[]`                     |
 | `ingress.extraRules`               | Additional rules to be covered with this ingress record                                                                          | `[]`                     |
 
 ### Other Parameters
@@ -400,7 +377,6 @@ console, we recommend you to look at our
 - [Install without Conduktor monitoring](#install-without-conduktor-monitoring)
 
 ### Kubernetes configuration
-
 - [Install with an enterprise license](#install-with-an-enterprise-license)
 - [Install with a basic SSO configuration](#install-with-a-basic-sso-configuration)
 - [Install with a Kafka cluster](#install-with-a-kafka-cluster)
@@ -415,8 +391,15 @@ console, we recommend you to look at our
 - [Provide console configuration as a Kubernetes ConfigMap](#provide-console-configuration-as-a-kubernetes-configmap)
 - [Provide additional credentials as a Kubernetes Secret](#provide-additional-credentials-as-a-kubernetes-secret)
 - [Install with a toleration](#install-with-a-toleration)
-- [Install with Self-Signed TLS certificate](#install-with-self-signed-tls-certificate)
-- [Install with a custom TLS certificate on the platform Pod](#install-with-a-custom-tls-certificate-on-the-platform-pod)
+- [Ingress TLS configuration](#ingress-tls-configuration)
+  - [Using cert-manager](#using-cert-manager)
+  - [Using existing TLS secret](#using-existing-tls-secret)
+  - [Using plain PEM certificate and key](#using-plain-pem-certificate-and-key)
+  - [Using Multiple TLS secrets](#using-multiple-tls-secrets)
+  - [Using Helm generated self-signed certificates](#using-helm-generated-self-signed-certificates)
+- [Container TLS configuration](#container-tls-configuration)
+  - [Use an existing secret](#use-an-existing-secret-)
+  - [Install with Self-Signed TLS certificate](#install-with-self-signed-tls-certificate)
 - [Install with a custom service account](#install-with-a-custom-service-account)
 - [Install with a AWS EKS IAM Role](#install-with-a-aws-eks-iam-role)
 - [Install with Console technical monitoring](#install-with-console-technical-monitoring)
@@ -903,32 +886,103 @@ platformCortex:
       effect: "NoSchedule"
 ```
 
-### Install with Self-Signed TLS certificate
+### Ingress TLS configuration
 
+#### Using cert-manager
+This solution leverage [cert-manager](https://cert-manager.io/docs/) to generate TLS certificates for your ingress simply using annotations.
+
+Example using a [Nginx Ingress](https://kubernetes.github.io/ingress-nginx/) and cert-manager with [Let's Encrypt](https://cert-manager.io/docs/tutorials/acme/pomerium-ingress/#configure-lets-encrypt-issuer) issuer : 
 ```yaml
-config:
-  organization:
-    name: "my-org"
-
-  admin:
-    email: "admin@my-org.com"
-    password: "admin"
-
-  database:
-    host: ""
-    port: 5432
-    name: "postgres"
-    username: ""
-    password: ""
-
-  platform:
-    external:
-      url: "https://platform.local"
-    https:
-      selfSigned: true
+ingress:
+  enabled: true
+  hostname: conduktor-console.my-domain.com
+  tls: true
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-issuer
+    kubernetes.io/ingress.class: nginx
 ```
 
-### Install with a custom TLS certificate on the platform Pod
+#### Using existing TLS secret
+If you already have a TLS secret of type `kubernetes.io/tls` created in your cluster, you can use it in your ingress configuration.
+
+```yaml
+ingress:
+  enabled: true
+  hostname: conduktor-console.my-domain.com
+  tls: true
+  secrets:
+    - name: my-existing-tls-secret
+```
+OR using `ingress.extraTls`
+```yaml
+ingress:
+  enabled: true
+  hostname: conduktor-console.my-domain.com
+  extraTls:
+    - secretName: my-existing-tls-secret
+      hosts:
+        - conduktor-console.my-domain.com
+```
+
+#### Using plain PEM certificate and key
+
+If you have a PEM certificate and key, you can use them directly in your `values.yaml` file.
+```yaml
+ingress:
+  enabled: true
+  hostname: conduktor-console.my-domain.com
+  tls: true
+  secrets:
+    - name: my-new-tls-secret
+      certificate: |-
+        -----BEGIN CERTIFICATE-----
+        ...
+        -----END CERTIFICATE-----
+      key: |-
+        -----BEGIN PRIVATE KEY-----
+        ...
+        -----END PRIVATE KEY-----
+```
+
+#### Using Multiple TLS secrets
+
+If using multiple hostnames, you can use the `extraTls` parameter to add more TLS secrets.
+
+```yaml
+ingress:
+  enabled: true
+  hostname: conduktor-console.my-domain.com
+  extraHosts:
+    - host: my-other-hostname.com
+      path: /
+      pathType: ImplementationSpecific
+  tls: true
+  extraTls:
+    - secretName: conduktor-console.my-domain.com-tls
+      hosts:
+        - conduktor-console.my-domain.com
+    - secretName: my-other-hostname.com-tls
+      hosts:
+        - my-other-hostname.com
+```
+
+#### Using Helm generated self-signed certificates
+This solution use Helm [`genCA`](https://helm.sh/docs/chart_template_guide/function_list/#genca), [`genSignedCert`](https://helm.sh/docs/chart_template_guide/function_list/#gensignedcert) functions to generate self-signed certificates for your ingress. (Not for production use)
+```yaml
+ingress:
+  enabled: true
+  hostname: conduktor-console.my-domain.com
+  tls: true
+  selfSigned: true
+```
+It will generate a secret name `<hostname>-tls` with the certificates and key.
+
+### Container TLS configuration
+
+#### Use an existing secret 
+
+If you already have a TLS secret of type `kubernetes.io/tls` created in your cluster, you can use it in your platform configuration.
+At startup Console will look for a `tls.crt` and `tls.key` PEM inside the secret to be mounted.
 
 ```yaml
 config:
@@ -952,18 +1006,35 @@ config:
     https:
       selfSigned: false
       existingSecret: "platform-tls"
-ingress:
-  secrets:
-    - name: platform-tls
-      certificate: |-
-        -----BEGIN CERTIFICATE-----
-        ...
-        -----END CERTIFICATE-----
-      key: |-
-        -----BEGIN PRIVATE KEY-----
-        ...
-        -----END PRIVATE KEY-----
 ```
+
+#### Install with Self-Signed TLS certificate
+
+This solution use Helm[`genCA`](https://helm.sh/docs/chart_template_guide/function_list/#genca), [`genSignedCert`](https://helm.sh/docs/chart_template_guide/function_list/#gensignedcert) functions to generate self-signed certificates using `config.platform.external.url` for the certificate subject name CN. (Not for production use)
+
+```yaml
+config:
+  organization:
+    name: "my-org"
+
+  admin:
+    email: "admin@my-org.com"
+    password: "admin"
+
+  database:
+    host: ""
+    port: 5432
+    name: "postgres"
+    username: ""
+    password: ""
+
+  platform:
+    external:
+      url: "https://platform.local"
+    https:
+      selfSigned: true
+```
+Self signed secret will be stored inside a secret named `<fullname>-platform-tls`.
 
 ### Install with a custom service account
 

--- a/charts/console/README.md
+++ b/charts/console/README.md
@@ -918,6 +918,7 @@ OR using `ingress.extraTls`
 ingress:
   enabled: true
   hostname: conduktor-console.my-domain.com
+  tls: true
   extraTls:
     - secretName: my-existing-tls-secret
       hosts:
@@ -952,11 +953,11 @@ If using multiple hostnames, you can use the `extraTls` parameter to add more TL
 ingress:
   enabled: true
   hostname: conduktor-console.my-domain.com
+  tls: true
   extraHosts:
     - host: my-other-hostname.com
       path: /
       pathType: ImplementationSpecific
-  tls: true
   extraTls:
     - secretName: conduktor-console.my-domain.com-tls
       hosts:

--- a/charts/console/ci/03-pod-tls-existingSecret-values.yaml
+++ b/charts/console/ci/03-pod-tls-existingSecret-values.yaml
@@ -104,4 +104,3 @@ tests:
           wvgKzW/jdP22DuI9njmCzeX6Qy+Ip6tBUe5A+fi5uQ1sqZj3jPB/9GOf/etw+Jes
           Q33adkf6WrEn/aN9RAFyiAY=
           -----END PRIVATE KEY-----
-

--- a/charts/console/ci/06-ingress-tls-selfsigned-values.yaml
+++ b/charts/console/ci/06-ingress-tls-selfsigned-values.yaml
@@ -1,0 +1,45 @@
+# Test is checking:
+# - generate a self-signed certificate for the platform
+# - connectivity between the platform and the monitoring pod using self-signed certificate
+nameOverride: cdkt-test-06
+config:
+  admin:
+    email: admin@conduktor.io
+    password: testP4ss!
+
+  database:
+    name: platform
+    host: postgresql-hl
+    password: conduktor123
+    port: 5432
+    username: postgres
+
+platform:
+  startupProbe:
+    initialDelaySeconds: 60  # extra delay because of limited cpu resources
+  terminationGracePeriodSeconds: 0  # quick kill between tests
+  resources:
+    limits:
+      cpu: 1000m
+      memory: 2Gi
+    requests:
+      cpu: 500m
+      memory: 1Gi
+
+platformCortex:
+  resources:
+    limits:
+      cpu: 500m
+      memory: 400Mi
+    requests:
+      cpu: 200m
+      memory: 200Mi
+
+ingress:
+  enabled: true
+  hostname: platform.cluster.local
+  tls: true
+  selfSigned: true
+
+tests:
+  enabled: true

--- a/charts/console/ci/07-ingress-tls-existing-secret-values.yaml
+++ b/charts/console/ci/07-ingress-tls-existing-secret-values.yaml
@@ -98,4 +98,3 @@ tests:
           wvgKzW/jdP22DuI9njmCzeX6Qy+Ip6tBUe5A+fi5uQ1sqZj3jPB/9GOf/etw+Jes
           Q33adkf6WrEn/aN9RAFyiAY=
           -----END PRIVATE KEY-----
-

--- a/charts/console/ci/07-ingress-tls-existing-secret-values.yaml
+++ b/charts/console/ci/07-ingress-tls-existing-secret-values.yaml
@@ -1,10 +1,8 @@
 # Test is checking:
-# - use existing secret for platform tls
-# - connectivity between the platform and the monitoring pod skipping tls verification
-nameOverride: cdkt-test-03
+# - generate a self-signed certificate for the platform
+# - connectivity between the platform and the monitoring pod using self-signed certificate
+nameOverride: cdkt-test-07
 config:
-  organization:
-    name: conduktor
   admin:
     email: admin@conduktor.io
     password: testP4ss!
@@ -16,28 +14,17 @@ config:
     port: 5432
     username: postgres
 
-  platform:
-    external:
-      url: "https://platform.cluster.local"
-    https:
-      selfSigned: false
-      existingSecret: "cdkt-test-03-tls"
-
-monitoringConfig:
-  scraper:
-    skipSSLCheck: true
-
 platform:
   startupProbe:
     initialDelaySeconds: 60  # extra delay because of limited cpu resources
   terminationGracePeriodSeconds: 0  # quick kill between tests
   resources:
     limits:
-      cpu: 1500m
-      memory: 3Gi
+      cpu: 1000m
+      memory: 2Gi
     requests:
       cpu: 500m
-      memory: 2Gi
+      memory: 1Gi
 
 platformCortex:
   resources:
@@ -48,10 +35,17 @@ platformCortex:
       cpu: 200m
       memory: 200Mi
 
+ingress:
+  enabled: true
+  hostname: platform.cluster.local
+  tls: true
+  secrets:
+    - name: cdkt-test-07-tls
+
 tests:
   enabled: true
   secrets:
-    - name: cdkt-test-03-tls
+    - name: cdkt-test-07-tls
       type: kubernetes.io/tls
       stringData:
         tls.crt: |-

--- a/charts/console/ci/08-ingress-tls-plain-pem-values.yaml
+++ b/charts/console/ci/08-ingress-tls-plain-pem-values.yaml
@@ -1,0 +1,95 @@
+# Test is checking:
+# - generate a self-signed certificate for the platform
+# - connectivity between the platform and the monitoring pod using self-signed certificate
+nameOverride: cdkt-test-08
+config:
+  admin:
+    email: admin@conduktor.io
+    password: testP4ss!
+
+  database:
+    name: platform
+    host: postgresql-hl
+    password: conduktor123
+    port: 5432
+    username: postgres
+
+platform:
+  startupProbe:
+    initialDelaySeconds: 60  # extra delay because of limited cpu resources
+  terminationGracePeriodSeconds: 0  # quick kill between tests
+  resources:
+    limits:
+      cpu: 1000m
+      memory: 2Gi
+    requests:
+      cpu: 500m
+      memory: 1Gi
+
+platformCortex:
+  resources:
+    limits:
+      cpu: 500m
+      memory: 400Mi
+    requests:
+      cpu: 200m
+      memory: 200Mi
+
+ingress:
+  enabled: true
+  hostname: platform.cluster.local
+  tls: true
+  secrets:
+    - name: cdkt-test-08-tls
+      certificate: |-
+        -----BEGIN CERTIFICATE-----
+        MIIDNjCCAh6gAwIBAgIUP7t+XFOtCuqOuBe0YWj/XrUSNS0wDQYJKoZIhvcNAQEL
+        BQAwITEfMB0GA1UEAwwWcGxhdGZvcm0uY2x1c3Rlci5sb2NhbDAeFw0yMzA4MTEx
+        NDEzMDJaFw0yMzA5MTAxNDEzMDJaMCExHzAdBgNVBAMMFnBsYXRmb3JtLmNsdXN0
+        ZXIubG9jYWwwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCmfcTsrw0b
+        hGeHm1ODH4ULOO5smnHLN6VRkv4asswSKrU+9yyknINfzZ42LPA2zVkhWnr3qAUl
+        xl5zXUSxyYme+xXEta3SowK1BUBiJvkwry39B3q05+lR/aCYEyo/aKXQ1smFrs0t
+        JX2dFNby4Lxn8RYjXgVnz2aFxkEAn0sTTY9wCFrCbyvAJAQSWnKiWDulGv0l3z5q
+        rXbWuqbKfNclk/EkMo9/JB8fAEKxDHpcer7sm4L5q8zFrZeubhNRKsd39vc4nwqh
+        I5dLuuetI5WkEv2d74AQJHhrTLMsO2GcQN1LQl5a/mP6K4oJ3XhIH8Uw1+KW9soU
+        NqjWY7RNDm1xAgMBAAGjZjBkMCEGA1UdEQQaMBiCFnBsYXRmb3JtLmNsdXN0ZXIu
+        bG9jYWwwCwYDVR0PBAQDAgeAMBMGA1UdJQQMMAoGCCsGAQUFBwMBMB0GA1UdDgQW
+        BBRwPeqPdyGShBKjUdVIO84EvDixujANBgkqhkiG9w0BAQsFAAOCAQEAQxdeGfEl
+        XD5ZpiZg5zVvULJEZaT6HcdJ3iTgIKRmuJK6xi6eM4fWHHlJA11S/d+CEqzjqTwV
+        PHQf3ZAxhWAhM8Kdwnhk+8j5eMzCUj4OiXbqLamhKAUkfNckOSP0DxHOPG26qLmX
+        Av2TtG2z/XQe70aMBhXhPlbk60Dr0py6anR/51ppBf+d/O4wxIZYWtS72dYzLUFI
+        icqrHKwIBmBy54MJijUmM5QC7qUSemncjZco5XDPaquirQI1i0yRebla3WqfO4II
+        S/Ukxk0mgZeQ+pVnNgrPRNktcsaFw/TRoqhh7BU67DSSipdeXXVCiRG9eVTxEpY3
+        aCVYlF1cM8BoHw==
+        -----END CERTIFICATE-----
+      key: |-
+        -----BEGIN PRIVATE KEY-----
+        MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQCmfcTsrw0bhGeH
+        m1ODH4ULOO5smnHLN6VRkv4asswSKrU+9yyknINfzZ42LPA2zVkhWnr3qAUlxl5z
+        XUSxyYme+xXEta3SowK1BUBiJvkwry39B3q05+lR/aCYEyo/aKXQ1smFrs0tJX2d
+        FNby4Lxn8RYjXgVnz2aFxkEAn0sTTY9wCFrCbyvAJAQSWnKiWDulGv0l3z5qrXbW
+        uqbKfNclk/EkMo9/JB8fAEKxDHpcer7sm4L5q8zFrZeubhNRKsd39vc4nwqhI5dL
+        uuetI5WkEv2d74AQJHhrTLMsO2GcQN1LQl5a/mP6K4oJ3XhIH8Uw1+KW9soUNqjW
+        Y7RNDm1xAgMBAAECggEAARNQ7esEAewVit53wCVLlvoOR+rWVOoPBHwqh0+/IjFb
+        tO+0VOHuFl5Z6qoyReLzg9Pgu9f7KtTJfdPOnpPuPBXnP86HlDO7CY78A18Y883K
+        4lG6b7/lTbMec6MHWwwTd6CRwhryC3jMtmkI1sSfvokws8GbvEFrRvsqWfOddzJb
+        Z3nGRW6qclYOSjyrsNUJYfmDiir59EQZd0MojwMXdJR9seX/3ORs5f38vYIIhaIv
+        IrnOKGdVdvpP7EhTD5Ul/0Y/chrxvW5UrKtynC3FT4GSjDtLLEFJudC9hpnIHiEj
+        mZas8JJfucZ3AYpFPgmLSZuX2MFhZZTKrJ/j6vw7QQKBgQDYYaF6Ev8WTqE1tT1q
+        n6yLQbfc34O4SpVAd0qTOva3fuRQZ2RuuTgA6IaElTqFkk+H86agk/yqLJDqKbjm
+        +tbfsMdhTQMGtCjbydg6CW5Fs1+r/n7Pkg+eoWUTIFqTJ1totnu7RtQtR2osmWmK
+        X1hk7C63CxDXsB6nNKqRLQz0QQKBgQDE+ahkqyb0sGxByUDYFbPliUCSpU2+5d2U
+        rdcIO4F07Q4GQtJejNQzEKLrYd6+NhWs11rVrXYwlS4fm/nOIBgQy154KKWM04QL
+        q4mCeCCQxcDHbVRPb51TF9nMLl9wQeY7NuaQbMFlErb5pIDKS1Nt0BFSlPmquYwl
+        kokx9JRtMQKBgGxhano0raREuiamox6W39vYjPmK0vUqFlv15FqefBko678CKqHz
+        EAQUc9xQysFAqalU9y8TMMkkDWncgArhtWLRruwjoNJoxtZf4XggZSVwVQlXLblW
+        VZCFEpVj7TorynNGg+8n6PrM/HdeWCjA3Quf6T4xwrvmMVRa4txYjlaBAoGAFQC5
+        3+IQCU82e91FuMS3peX4qKpPm+dOtSfEIfCWYS1VrX06iTJi/f7sIEUTRxzlOsTL
+        vrT8QTnm7R/ohv4NEt1ceVt8K4PyNHxZ8Tt13Xn4kEssDjxMfiuw4YCgVIvyTKYR
+        95xhErHoKL5NrURS5QamkjOoW3flZaw2TMlTekECgYEAnRMZQTESwA5Mp311Cggx
+        CuYIXw/G4Dk/pD7VTvdTTaJY+ShUXLcOCeri1UysQc2L1C6owgvzhr6oMymJirYX
+        wvgKzW/jdP22DuI9njmCzeX6Qy+Ip6tBUe5A+fi5uQ1sqZj3jPB/9GOf/etw+Jes
+        Q33adkf6WrEn/aN9RAFyiAY=
+
+tests:
+  enabled: true

--- a/charts/console/templates/console/ingress-tls-secret.yaml
+++ b/charts/console/templates/console/ingress-tls-secret.yaml
@@ -1,5 +1,6 @@
 {{- if .Values.ingress.secrets }}
 {{- range .Values.ingress.secrets }}
+{{- if (and .certificate .key) }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -18,6 +19,8 @@ data:
   tls.crt: {{ .certificate | b64enc }}
   tls.key: {{ .key | b64enc }}
 ---
+{{- end }}
+{{- end }}
 {{- end }}
 {{- if and .Values.ingress.tls .Values.ingress.selfSigned }}
 {{- $secretName := printf "%s-tls" .Values.ingress.hostname }}
@@ -42,4 +45,4 @@ data:
   tls.key: {{ include "common.secrets.lookup" (dict "secret" $secretName "key" "tls.key" "defaultValue" $cert.Key "context" $) }}
   ca.crt: {{ include "common.secrets.lookup" (dict "secret" $secretName "key" "ca.crt" "defaultValue" $ca.Cert "context" $) }}
 {{- end }}
-{{- end }}
+

--- a/charts/console/templates/console/ingress.yaml
+++ b/charts/console/templates/console/ingress.yaml
@@ -49,12 +49,25 @@ spec:
     {{- if .Values.ingress.extraRules }}
     {{- include "common.tplvalues.render" (dict "value" .Values.ingress.extraRules "context" $) | nindent 4 }}
     {{- end }}
-  {{- if or (and .Values.ingress.tls (or (include "common.ingress.certManagerRequest" ( dict "annotations" .Values.ingress.annotations )) .Values.ingress.selfSigned)) .Values.ingress.extraTls }}
+  {{- $useCertManager := (include "common.ingress.certManagerRequest" ( dict "annotations" .Values.ingress.annotations )) }}
+  {{- $useSelfSigned := .Values.ingress.selfSigned }}
+  {{- $useSecrets := .Values.ingress.secrets }}
+  {{- if or .Values.ingress.tls .Values.ingress.extraTls }}
   tls:
-    {{- if and .Values.ingress.tls (or (include "common.ingress.certManagerRequest" ( dict "annotations" .Values.ingress.annotations )) .Values.ingress.selfSigned) }}
+    {{- if .Values.ingress.tls }}
+    {{- $_ := required "Ingress TLS enabled require one of : \n- ingress.selfSigned \n- ingress.secrets with existing TLS secret or one to create \n- ingress.annotations for cert-manager"  (coalesce $useCertManager $useSelfSigned $useSecrets) }}
+    {{- if or $useCertManager $useSelfSigned }}
     - hosts:
         - {{ .Values.ingress.hostname | quote }}
       secretName: {{ printf "%s-tls" .Values.ingress.hostname }}
+    {{- end }}
+    {{- if $useSecrets }}
+    {{- range $secret := .Values.ingress.secrets }}
+    - hosts:
+        - {{ $.Values.ingress.hostname | quote }}
+      secretName: {{ $secret.name | quote }}
+    {{- end }}
+    {{- end }}
     {{- end }}
     {{- if .Values.ingress.extraTls }}
     {{- include "common.tplvalues.render" (dict "value" .Values.ingress.extraTls "context" $) | nindent 4 }}

--- a/charts/console/values.yaml
+++ b/charts/console/values.yaml
@@ -704,15 +704,15 @@ ingress:
   ##   secretName: platform.local-tls
   ##
   extraTls: []
-  ## @param ingress.secrets Custom TLS certificates as secrets
+  ## @param ingress.secrets Existing TLS secrets or custom TLS certificates/keys secrets to create and use
   ## NOTE: 'key' and 'certificate' are expected in PEM format
-  ## NOTE: 'name' should line up with a 'secretName' set further up
   ## If it is not set and you're using cert-manager, this is unneeded, as it will create a secret for you with valid certificates
   ## If it is not set and you're NOT using cert-manager either, self-signed certificates will be created valid for 365 days
-  ## It is also possible to create and manage the certificates outside of this helm chart
+  ## It is also possible to create and manage the certificates outside of this helm chart by just set existing secret name in secrets[].name without key and certificate values.
   ## e.g:
   ## secrets:
-  ##   - name: platform.local-tls
+  ##   - name: existing-secret-tls # existing TLS secret
+  ##   - name: platform.local-tls  # new TLS secret with key and certificate values for tls.cert and tls.key keys
   ##     key: |-
   ##       -----BEGIN RSA PRIVATE KEY-----
   ##       ...


### PR DESCRIPTION
- Document ingress TLS configuration using : 
  - cert-manager 
  - existing TLS secret
  - plain certificates/key in PEM
  - multiple hostnames TLS
  - helm self-signed generated certificate
- Fix bug when `ingress.secrets` are not use in ingress tls section 
- Add new tests for ingress TLS cases
- Throw an error if `ingress.tls` is enabled but no tls configuration is set
- Also cleanup documentation snippets and test on container TLS configuration. 