### PR TITLE
Fix Console ServiceMonitor when TLS is enabled on pod

### DIFF
--- a/charts/console/README.md
+++ b/charts/console/README.md
@@ -213,27 +213,29 @@ Refer to our [documentation](https://docs.conduktor.io/platform/configuration/co
 
 Console expose metrics that could be collected and presented if your environment have the necessary components (Prometheus and Grafana operators)
 
-| Name                                                | Description                                                                                            | Value                    |
-| --------------------------------------------------- | ------------------------------------------------------------------------------------------------------ | ------------------------ |
-| `platform.metrics.enabled`                          | Enable the export of Prometheus metrics                                                                | `false`                  |
-| `platform.metrics.serviceMonitor.enabled`           | if `true`, creates a Prometheus Operator ServiceMonitor (also requires `metrics.enabled` to be `true`) | `false`                  |
-| `platform.metrics.serviceMonitor.namespace`         | Namespace in which Prometheus is running                                                               | `""`                     |
-| `platform.metrics.serviceMonitor.annotations`       | Additional custom annotations for the ServiceMonitor                                                   | `{}`                     |
-| `platform.metrics.serviceMonitor.labels`            | Extra labels for the ServiceMonitor                                                                    | `{}`                     |
-| `platform.metrics.serviceMonitor.jobLabel`          | The name of the label on the target service to use as the job name in Prometheus                       | `app.kubernetes.io/name` |
-| `platform.metrics.serviceMonitor.honorLabels`       | honorLabels chooses the metric's labels on collisions with target labels                               | `false`                  |
-| `platform.metrics.serviceMonitor.interval`          | Interval at which metrics should be scraped.                                                           | `""`                     |
-| `platform.metrics.serviceMonitor.scrapeTimeout`     | Timeout after which the scrape is ended                                                                | `""`                     |
-| `platform.metrics.serviceMonitor.metricRelabelings` | Specify additional relabeling of metrics                                                               | `[]`                     |
-| `platform.metrics.serviceMonitor.relabelings`       | Specify general relabeling                                                                             | `[]`                     |
-| `platform.metrics.serviceMonitor.selector`          | Prometheus instance selector labels                                                                    | `{}`                     |
-| `platform.metrics.serviceMonitor.extraParams`       | Extra parameters for the ServiceMonitor                                                                | `{}`                     |
-| `platform.metrics.grafana.enabled`                  | Enable grafana dashboards to installation                                                              | `false`                  |
-| `platform.metrics.grafana.namespace`                | Namespace used to deploy Grafana dashboards by default use the same namespace as Conduktor Csonsole    | `""`                     |
-| `platform.metrics.grafana.matchLabels`              | Label selector for Grafana instance                                                                    | `{}`                     |
-| `platform.metrics.grafana.labels`                   | Additional custom labels for Grafana dashboard ConfigMap                                               | `{}`                     |
-| `platform.metrics.grafana.folder`                   | Grafana dashboard folder name                                                                          | `""`                     |
-| `platform.metrics.grafana.datasources.prometheus`   | Prometheus datasource to use for metric dashboard                                                      | `prometheus`             |
+| Name                                                | Description                                                                                                                                                                 | Value                    |
+| --------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------ |
+| `platform.metrics.enabled`                          | Enable the export of Prometheus metrics                                                                                                                                     | `false`                  |
+| `platform.metrics.serviceMonitor.enabled`           | if `true`, creates a Prometheus Operator ServiceMonitor (also requires `metrics.enabled` to be `true`)                                                                      | `false`                  |
+| `platform.metrics.serviceMonitor.namespace`         | Namespace in which Prometheus is running                                                                                                                                    | `""`                     |
+| `platform.metrics.serviceMonitor.annotations`       | Additional custom annotations for the ServiceMonitor                                                                                                                        | `{}`                     |
+| `platform.metrics.serviceMonitor.labels`            | Extra labels for the ServiceMonitor                                                                                                                                         | `{}`                     |
+| `platform.metrics.serviceMonitor.jobLabel`          | The name of the label on the target service to use as the job name in Prometheus                                                                                            | `app.kubernetes.io/name` |
+| `platform.metrics.serviceMonitor.honorLabels`       | honorLabels chooses the metric's labels on collisions with target labels                                                                                                    | `false`                  |
+| `platform.metrics.serviceMonitor.interval`          | Interval at which metrics should be scraped.                                                                                                                                | `""`                     |
+| `platform.metrics.serviceMonitor.scheme`            | Protocol scheme to use for scraping (http or https). By default, automatically resolved based on container TLS configuration.                                               | `""`                     |
+| `platform.metrics.serviceMonitor.tlsConfig`         | TLS configuration for the ServiceMonitor. By default, automatically resolved based on container TLS configuration using config.platform.https config and tls.crt in secret. | `{}`                     |
+| `platform.metrics.serviceMonitor.scrapeTimeout`     | Timeout after which the scrape is ended                                                                                                                                     | `""`                     |
+| `platform.metrics.serviceMonitor.metricRelabelings` | Specify additional relabeling of metrics                                                                                                                                    | `[]`                     |
+| `platform.metrics.serviceMonitor.relabelings`       | Specify general relabeling                                                                                                                                                  | `[]`                     |
+| `platform.metrics.serviceMonitor.selector`          | Prometheus instance selector labels                                                                                                                                         | `{}`                     |
+| `platform.metrics.serviceMonitor.extraParams`       | Extra parameters for the ServiceMonitor                                                                                                                                     | `{}`                     |
+| `platform.metrics.grafana.enabled`                  | Enable grafana dashboards to installation                                                                                                                                   | `false`                  |
+| `platform.metrics.grafana.namespace`                | Namespace used to deploy Grafana dashboards by default use the same namespace as Conduktor Csonsole                                                                         | `""`                     |
+| `platform.metrics.grafana.matchLabels`              | Label selector for Grafana instance                                                                                                                                         | `{}`                     |
+| `platform.metrics.grafana.labels`                   | Additional custom labels for Grafana dashboard ConfigMap                                                                                                                    | `{}`                     |
+| `platform.metrics.grafana.folder`                   | Grafana dashboard folder name                                                                                                                                               | `""`                     |
+| `platform.metrics.grafana.datasources.prometheus`   | Prometheus datasource to use for metric dashboard                                                                                                                           | `prometheus`             |
 
 ### Traffic Exposure Parameters
 

--- a/charts/console/templates/_helpers.tpl
+++ b/charts/console/templates/_helpers.tpl
@@ -227,6 +227,14 @@ Platform external url. Fallback to internal one if no external url configured or
 {{- end -}}
 {{- end -}}
 
+{{/*
+Return the external hostname of the platform without protocol and port
+*/}}
+{{- define "conduktor.platform.externalHostname" -}}
+{{- $externalUrl := include "conduktor.platform.externalUrl" . -}}
+{{- $parsedUrl := urlParse $externalUrl -}}
+{{- $parsedUrl.hostname -}}
+{{- end -}}
 
 {{/*
 Name of the platform cortex Service

--- a/charts/console/templates/console/servicemonitor.yaml
+++ b/charts/console/templates/console/servicemonitor.yaml
@@ -1,5 +1,6 @@
 {{- if .Capabilities.APIVersions.Has "monitoring.coreos.com/v1/ServiceMonitor" }}
 {{- if and .Values.platform.metrics.enabled .Values.platform.metrics.serviceMonitor.enabled }}
+{{- $isSSLEnabled := not (empty (include "conduktor.platform.tls.enabled" .)) }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
@@ -28,7 +29,11 @@ spec:
   endpoints:
     - port: http
       path: "/api/metrics"
-      scheme: http
+      {{- if .Values.platform.metrics.serviceMonitor.scheme }}
+      scheme: {{ .Values.platform.metrics.serviceMonitor.scheme }}
+      {{- else }}
+      scheme: {{ ternary "https" "http" $isSSLEnabled }}
+      {{- end }}
       {{- if .Values.platform.metrics.serviceMonitor.interval }}
       interval: {{ .Values.platform.metrics.serviceMonitor.interval }}
       {{- end }}
@@ -43,6 +48,18 @@ spec:
       {{- end }}
       {{- if .Values.platform.metrics.serviceMonitor.relabelings }}
       relabelings: {{- include "common.tplvalues.render" ( dict "value" .Values.platform.metrics.serviceMonitor.relabelings "context" $) | nindent 8 }}
+      {{- end }}
+      {{- if .Values.platform.metrics.serviceMonitor.tlsConfig }}
+      tlsConfig: {{- include "common.tplvalues.render" ( dict "value" .Values.platform.metrics.serviceMonitor.tlsConfig "context" $) | nindent 8 }}
+      {{- else }}
+      {{- if $isSSLEnabled }}
+      tlsConfig:
+        serverName: {{ include "conduktor.platform.externalHostname" . | quote }}
+        ca:
+          secret:
+            name: {{ include "conduktor.platform.tls.secretName" . | quote}}
+            key: "tls.crt"
+      {{- end }}
       {{- end }}
       {{- if .Values.platform.metrics.serviceMonitor.extraParams }}
       {{- toYaml .Values.platform.metrics.serviceMonitor.extraParams | nindent 6 }}

--- a/charts/console/values.yaml
+++ b/charts/console/values.yaml
@@ -522,6 +522,10 @@ platform:
       ## interval: 10s
       ##
       interval: ""
+      ## @param platform.metrics.serviceMonitor.scheme Protocol scheme to use for scraping (http or https). By default, automatically resolved based on container TLS configuration.
+      scheme: ""
+      ## @param platform.metrics.serviceMonitor.tlsConfig TLS configuration for the ServiceMonitor. By default, automatically resolved based on container TLS configuration using config.platform.https config and tls.crt in secret.
+      tlsConfig: {}
       ## @param platform.metrics.serviceMonitor.scrapeTimeout Timeout after which the scrape is ended
       ## ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#endpoint
       ## e.g:


### PR DESCRIPTION
Fix ServiceMonitor configuration if TLS is enabled on Console pod. 
Make configurable service monitor `scheme` and `tlsConfig` with `platform.metrics.serviceMonitor.scheme` / `platform.metrics.serviceMonitor.tlsConfig`
Try to automatically configure tlsConfig using `config.platform.externalURL` and `config.platform.https.*` configs