### PR TITLE
Add support for initContainers and sidecars containers in Gateway Pod

### DIFF
--- a/charts/gateway/README.md
+++ b/charts/gateway/README.md
@@ -35,10 +35,11 @@ Global Docker image parameters
 Please, note that this will override the image parameters, including dependencies, configured to use the global value
 Current available global Docker image parameters: imageRegistry, imagePullSecrets and storageClass
 
-| Name                      | Description                              | Value |
-| ------------------------- | ---------------------------------------- | ----- |
-| `global.imagePullSecrets` | Docker login secrets name for image pull | `[]`  |
-| `global.env`              | The environment name                     | `""`  |
+| Name                      | Description                                | Value |
+| ------------------------- | ------------------------------------------ | ----- |
+| `global.imageRegistry`    | Global Docker image registry               | `""`  |
+| `global.imagePullSecrets` | Docker login secrets name for image pull   | `[]`  |
+| `global.env`              | The environment name (deprecated not used) | `""`  |
 
 ### Common parameters
 
@@ -98,6 +99,8 @@ This section contains configuration of the Conduktor Gateway.
 | `gateway.securityContext`                    | Conduktor Gateway container Security Context                                                                                                                                                                                           | `{}`                                                                                                                                                                                                                                                                                                                        |
 | `gateway.volumes`                            | Define user specific volumes for Gateway deployment                                                                                                                                                                                    | `[]`                                                                                                                                                                                                                                                                                                                        |
 | `gateway.volumeMounts`                       | Define user specific volumeMounts for Gateway container in deployment                                                                                                                                                                  | `[]`                                                                                                                                                                                                                                                                                                                        |
+| `gateway.sidecars`                           | Add additional sidecar containers to run into the Conduktor Gateway pod(s)                                                                                                                                                             | `[]`                                                                                                                                                                                                                                                                                                                        |
+| `gateway.initContainers`                     | Add additional init containers to the Conduktor Gateway pod(s). ref: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/                                                                                               | `[]`                                                                                                                                                                                                                                                                                                                        |
 | `gateway.priorityClassName`                  | Define Gateway pods' priority based on an existing ClassName                                                                                                                                                                           | `""`                                                                                                                                                                                                                                                                                                                        |
 | `gateway.customStartupProbe`                 | Custom startup probe configuration                                                                                                                                                                                                     | `{}`                                                                                                                                                                                                                                                                                                                        |
 | `gateway.startupProbe.enabled`               | Enable startupProbe on Conduktor Gaterway containers                                                                                                                                                                                   | `true`                                                                                                                                                                                                                                                                                                                      |
@@ -611,4 +614,39 @@ extraDeploy:
       name: extra-configmap
     data:
       some-key: some-value
+```
+
+### With init container
+
+You can use an init container to perform some actions before the Gateway container starts. This can be useful to prepare the environment or to run some scripts.
+
+```yaml
+gateway:
+  volumes:
+    - name: init-volume
+      emptyDir: {}
+  initContainers:
+    - name: init-container
+      image: busybox
+      command: ["sh", "-c", "echo 'Init container running'"]
+      volumeMounts:
+        - name: init-volume
+          mountPath: /mnt/init
+```
+
+### With sidecar container
+You can add a sidecar container to the Gateway deployment to run additional processes alongside the Gateway container. This can be useful for logging, monitoring, or other purposes.
+
+```yaml
+gateway:
+  volumes:
+    - name: sidecar-volume
+      emptyDir: {}
+  sidecars:
+    - name: sidecar-container
+      image: busybox
+      command: ["sh", "-c", "while true; do echo 'Sidecar container running'; sleep 10; done"]
+      volumeMounts:
+        - name: sidecar-volume
+          mountPath: /mnt/sidecar
 ```

--- a/charts/gateway/ci/03-complex-gateway-values.yaml
+++ b/charts/gateway/ci/03-complex-gateway-values.yaml
@@ -1,0 +1,44 @@
+nameOverride: gateway-test-01
+
+gateway:
+  replicas: 1
+  env:
+    KAFKA_BOOTSTRAP_SERVERS: kafka.default.svc.cluster.local:9092
+
+  securityContext:
+    capabilities:
+      drop:
+        - ALL
+    readOnlyRootFilesystem: true
+    runAsNonRoot: true
+    runAsUser: 1000
+
+  # Add volume on /tmp because of readOnlyRootFilesystem=true security constraint
+  volumes:
+    - name: tmp
+      emptyDir: {}
+  volumeMounts:
+    - name: tmp
+      mountPath: /tmp
+
+  initContainers:
+    - name: init-gw
+      image: busybox
+      command: ["sh", "-c", "echo 'Initializing Gateway'"]
+      volumeMounts:
+        - name: tmp
+          mountPath: /tmp
+
+  sidecars:
+    - name: sidecar-example
+      image: busybox
+      command: ["sh", "-c", "echo 'Running sidecar'"]
+      volumeMounts:
+        - name: tmp
+          mountPath: /tmp
+
+podSecurityContext:
+  runAsNonRoot: true
+
+tests:
+  enabled: true

--- a/charts/gateway/ci/03-complex-gateway-values.yaml
+++ b/charts/gateway/ci/03-complex-gateway-values.yaml
@@ -1,4 +1,4 @@
-nameOverride: gateway-test-01
+nameOverride: gateway-test-03
 
 gateway:
   replicas: 1
@@ -28,14 +28,28 @@ gateway:
       volumeMounts:
         - name: tmp
           mountPath: /tmp
+      securityContext:
+        capabilities:
+          drop:
+            - ALL
+        readOnlyRootFilesystem: true
+        runAsNonRoot: true
+        runAsUser: 1000
 
   sidecars:
     - name: sidecar-example
       image: busybox
-      command: ["sh", "-c", "echo 'Running sidecar'"]
+      command: ["sh", "-c", "while true; do echo 'Sidecar container running'; sleep 10; done"]
       volumeMounts:
         - name: tmp
           mountPath: /tmp
+      securityContext:
+        capabilities:
+          drop:
+            - ALL
+        readOnlyRootFilesystem: true
+        runAsNonRoot: true
+        runAsUser: 1000
 
 podSecurityContext:
   runAsNonRoot: true

--- a/charts/gateway/templates/deployment.yaml
+++ b/charts/gateway/templates/deployment.yaml
@@ -32,9 +32,13 @@ spec:
         {{- include "common.tplvalues.render" (dict "value" . "context" $) | nindent 8 }}
         {{- end }}
     spec:
+      initContainers:
+        {{- if .Values.gateway.initContainers }}
+          {{- include "common.tplvalues.render" (dict "value" .Values.gateway.initContainers "context" $) | nindent 8 }}
+        {{- end }}
       containers:
         - name: gateway
-          image: {{ .Values.gateway.image.registry }}/{{ .Values.gateway.image.repository }}:{{ .Values.gateway.image.tag }}
+          image: {{ include "common.images.image" (dict "imageRoot" .Values.gateway.image "global" .Values.global "chart" .Chart) }}
           imagePullPolicy: {{ .Values.gateway.image.pullPolicy }}
           env:
             # Static env var to be reconsidered if we offer env way to configure them
@@ -140,6 +144,9 @@ spec:
           {{- with .Values.gateway.securityContext }}
           securityContext: {{- toYaml . | nindent 12 }}
           {{- end }}
+        {{- if .Values.gateway.sidecars }}
+        {{- include "common.tplvalues.render" ( dict "value" .Values.gateway.sidecars "context" $) | nindent 8 }}
+        {{- end }}
       volumes:
         {{- with .Values.gateway.volumes }}
         {{- toYaml . | nindent 8 }}

--- a/charts/gateway/values.yaml
+++ b/charts/gateway/values.yaml
@@ -7,9 +7,11 @@
 ## Current available global Docker image parameters: imageRegistry, imagePullSecrets and storageClass
 ## @descriptionEnd
 global:
+  ## @param global.imageRegistry Global Docker image registry
+  imageRegistry: ""
   ## @param global.imagePullSecrets [array, nullable] Docker login secrets name for image pull
   imagePullSecrets: []
-  ## @param global.env The environment name
+  ## @param global.env The environment name (deprecated not used)
   env: ""
 
 ## @section Common parameters
@@ -162,6 +164,27 @@ gateway:
 
   ## @param gateway.volumeMounts Define user specific volumeMounts for Gateway container in deployment
   volumeMounts: []
+
+  ## @param gateway.sidecars Add additional sidecar containers to run into the Conduktor Gateway pod(s)
+  ## e.g:
+  ## sidecars:
+  ##   - name: your-image-name
+  ##     image: your-image
+  ##     imagePullPolicy: Always
+  ##     ports:
+  ##       - name: portname
+  ##         containerPort: 1234
+  ##
+  sidecars: []
+  ## @param gateway.initContainers Add additional init containers to the Conduktor Gateway pod(s). ref: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/
+  ## e.g:
+  ## initContainers:
+  ##  - name: your-image-name
+  ##    image: your-image
+  ##    imagePullPolicy: Always
+  ##    command: ['sh', '-c', 'echo "hello world"']
+  ##
+  initContainers: []
 
   ## @param gateway.priorityClassName Define Gateway pods' priority based on an existing ClassName
   priorityClassName: ""


### PR DESCRIPTION
- Add `gateway.initContainers` and `gateway.sidecars` containers supports
- Use Bitnami common to resolve gateway image and add `global.imageRegistry`