### PR TITLE
Fix issue with Console Grafana Dashboard

### DIFF
--- a/charts/console/templates/console/grafana-dashboards.yaml
+++ b/charts/console/templates/console/grafana-dashboards.yaml
@@ -104,8 +104,5 @@ spec:
       datasourceName: {{ .Values.platform.metrics.grafana.datasources.prometheus | quote }}
     - inputName: "INPUT_NAMESPACE"
       datasourceName: {{ include "common.names.namespace" . | quote }}
-  configMapRef:
-    name:  {{ $configMapName | quote }}
-    key: console.json
 {{- end }}
 {{- end }}


### PR DESCRIPTION
Fixed duplicate configMapRef in console grafana dashboard causing the error `mapping key "configMapRef" already defined`.