### PR TITLE
Remove new line trimming between Grafana dashboard resources

### DIFF
--- a/charts/console/templates/console/grafana-dashboards.yaml
+++ b/charts/console/templates/console/grafana-dashboards.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.platform.metrics.enabled .Values.platform.metrics.grafana.enabled }}
+{{ if and .Values.platform.metrics.enabled .Values.platform.metrics.grafana.enabled }}
 {{- $configMapName := printf "%s-dashboards" ( include "common.names.fullname" . | trunc 52) -}}
 {{- $consoleDashboard :=  .Files.Get "grafana-dashboards/console.json" | fromJson }}
 {{- $dashboardTitle := printf "Conduktor Console [%s]" (include "common.names.namespace" .) -}}
@@ -20,8 +20,8 @@ data:
   console.json: >
 {{ toPrettyJson $consoleDashboard | indent 4 }}
 ---
-{{- if .Values.platform.metrics.grafana.folder }}
-{{- if .Capabilities.APIVersions.Has "grafana.integreatly.org/v1beta1/GrafanaFolder" }}
+{{ if .Values.platform.metrics.grafana.folder }}
+{{ if .Capabilities.APIVersions.Has "grafana.integreatly.org/v1beta1/GrafanaFolder" }}
 {{- $consoleFolderName := printf "%s-%s" (include "common.names.fullname" .) "folder" | trunc 63 | trimSuffix "-" -}}
 apiVersion: grafana.integreatly.org/v1beta1
 kind: GrafanaFolder
@@ -44,7 +44,7 @@ spec:
 {{- end }}
 {{- end }}
 ---
-{{- if .Capabilities.APIVersions.Has "grafana.integreatly.org/v1beta1/GrafanaDashboard" }}
+{{ if .Capabilities.APIVersions.Has "grafana.integreatly.org/v1beta1/GrafanaDashboard" }}
 {{- $consoleDashboardName := printf "%s-%s" (include "common.names.fullname" .) "dashboards" | trunc 63 | trimSuffix "-" -}}
 apiVersion: grafana.integreatly.org/v1beta1
 kind: GrafanaDashboard
@@ -75,7 +75,7 @@ spec:
 {{- end }}
 ---
 {{/* Support for v4 of Grafana operator */}}
-{{- if .Capabilities.APIVersions.Has "integreatly.org/v1alpha1/GrafanaDashboard" }}
+{{ if .Capabilities.APIVersions.Has "integreatly.org/v1alpha1/GrafanaDashboard" }}
 {{- $consoleDashboardName := printf "%s-%s" (include "common.names.fullname" .) "dashboards" | trunc 63 | trimSuffix "-" -}}
 apiVersion: integreatly.org/v1alpha1
 kind: GrafanaDashboard


### PR DESCRIPTION
Fix templating errors 
```
Error: UPGRADE FAILED: error parsing : invalid Yaml document separator: apiVersion: grafana.integreatly.org/v1beta1
```
By removing template new line trimming between resources definitions.