### PR TITLE
Add extraSpecs to extend console and cortex services

### DIFF
--- a/charts/console/README.md
+++ b/charts/console/README.md
@@ -197,7 +197,7 @@ Refer to our [documentation](https://docs.conduktor.io/platform/configuration/co
 | `platform.priorityClassName`                  | Conduktor Console pods' priorityClassName                                                                                                                    | `""`                          |
 | `platform.topologySpreadConstraints`          | Topology Spread Constraints for pod assignment spread across your cluster among failure-domains. Evaluated as a template                                     | `[]`                          |
 | `platform.schedulerName`                      | Name of the k8s scheduler (other than default) for Conduktor Console pods                                                                                    | `""`                          |
-| `platform.terminationGracePeriodSeconds`      | Seconds Redmine pod needs to terminate gracefully                                                                                                            | `""`                          |
+| `platform.terminationGracePeriodSeconds`      | Seconds Redmine pod needs to terminate gracefully                                                                                                            | `30`                          |
 | `platform.lifecycleHooks`                     | for the Conduktor Console container(s) to automate configuration before or after startup                                                                     | `{}`                          |
 | `platform.dataVolume`                         | Configure the data volume to store Conduktor Console data                                                                                                    | `{}`                          |
 | `platform.tmpVolume`                          | Configure the /tmp volume which store various data related to running services                                                                               | `{}`                          |
@@ -252,6 +252,7 @@ Console expose metrics that could be collected and presented if your environment
 | `service.extraPorts`               | Extra ports to expose in Conduktor Console service (normally used with the `sidecars` value)                                     | `[]`                     |
 | `service.sessionAffinity`          | Control where client requests go, to the same pod or round-robin                                                                 | `None`                   |
 | `service.sessionAffinityConfig`    | Additional settings for the sessionAffinity                                                                                      | `{}`                     |
+| `service.extraSpecs`               | Extra specs for the service to be added under `spec` key                                                                         | `{}`                     |
 | `ingress.enabled`                  | Enable ingress record generation for Conduktor Console                                                                           | `false`                  |
 | `ingress.pathType`                 | Ingress path type                                                                                                                | `ImplementationSpecific` |
 | `ingress.apiVersion`               | Force Ingress API version (automatically detected if not set)                                                                    | `""`                     |
@@ -363,6 +364,7 @@ Console expose metrics that could be collected and presented if your environment
 | `platformCortex.service.extraPorts`                 | Extra ports to expose in Conduktor Console Cortex service (normally used with the `sidecars` value)                                                                 | `[]`                                 |
 | `platformCortex.service.sessionAffinity`            | Control where client requests go, to the same pod or round-robin                                                                                                    | `None`                               |
 | `platformCortex.service.sessionAffinityConfig`      | Additional settings for the sessionAffinity                                                                                                                         | `{}`                                 |
+| `platformCortex.service.extraSpecs`                 | Extra specs for the service to be added under `spec` key                                                                                                            | `{}`                                 |
 
 ## Snippets
 

--- a/charts/console/templates/console/service.yaml
+++ b/charts/console/templates/console/service.yaml
@@ -40,6 +40,9 @@ spec:
   {{- if and (eq .Values.service.type "LoadBalancer") (not (empty .Values.service.loadBalancerSourceRanges)) }}
   loadBalancerSourceRanges: {{ .Values.service.loadBalancerSourceRanges }}
   {{- end }}
+  {{- if .Values.service.extraSpecs }}
+  {{- include "common.tplvalues.render" (dict "value" .Values.service.extraSpecs "context" $) | nindent 2 }}
+  {{- end }}
   ports:
     - name: http
       port: {{ .Values.service.ports.http }}

--- a/charts/console/templates/cortex/service.yaml
+++ b/charts/console/templates/cortex/service.yaml
@@ -38,6 +38,9 @@ spec:
   {{- if and (eq .Values.platformCortex.service.type "LoadBalancer") (not (empty .Values.platformCortex.service.loadBalancerSourceRanges)) }}
   loadBalancerSourceRanges: {{ .Values.platformCortex.service.loadBalancerSourceRanges }}
   {{- end }}
+  {{- if .Values.platformCortex.service.extraSpecs }}
+  {{- include "common.tplvalues.render" (dict "value" .Values.platformCortex.service.extraSpecs "context" $) | nindent 2 }}
+  {{- end }}
   ports:
     - name: cortex
       port: {{ .Values.platformCortex.service.ports.cortex }}

--- a/charts/console/values.yaml
+++ b/charts/console/values.yaml
@@ -416,7 +416,7 @@ platform:
   ## @param platform.terminationGracePeriodSeconds Seconds Redmine pod needs to terminate gracefully
   ## ref: https://kubernetes.io/docs/concepts/workloads/pods/pod/#termination-of-pods
   ##
-  terminationGracePeriodSeconds: ""
+  terminationGracePeriodSeconds: 30
   ## @param platform.lifecycleHooks for the Conduktor Console container(s) to automate configuration before or after startup
   ##
   lifecycleHooks: {}
@@ -620,6 +620,12 @@ service:
   ##     timeoutSeconds: 300
   ##
   sessionAffinityConfig: {}
+  ## @param service.extraSpecs Extra specs for the service to be added under `spec` key
+  ## ref https://kubernetes.io/docs/reference/kubernetes-api/service-resources/service-v1/#ServiceSpec
+  ## extraSpecs:
+  ##   loadBalancerIP: "10.10.10.10"
+  extraSpecs: {}
+
 ## Conduktor Console ingress parameters
 ## ref: http://kubernetes.io/docs/user-guide/ingress/
 ##
@@ -1070,6 +1076,11 @@ platformCortex:
     ##     timeoutSeconds: 300
     ##
     sessionAffinityConfig: {}
+    ## @param platformCortex.service.extraSpecs Extra specs for the service to be added under `spec` key
+    ## ref https://kubernetes.io/docs/reference/kubernetes-api/service-resources/service-v1/#ServiceSpec
+    ## extraSpecs:
+    ##   loadBalancerIP: "10.10.10.10"
+    extraSpecs: {}
 ## @skip tests
 tests:
   enabled: false


### PR DESCRIPTION
Add `service.extraSpecs` and `platformCortex.service.extraSpecs` to extend Console and Console cortex services