### PR TITLE
Add extraSpecs to extend Gateway internal and external services

### DIFF
--- a/charts/gateway/README.md
+++ b/charts/gateway/README.md
@@ -145,24 +145,26 @@ This section contains Kubernetes services configuration.
 
 This section specifies external service configuration
 
-| Name                           | Description                                         | Value       |
-| ------------------------------ | --------------------------------------------------- | ----------- |
-| `service.external.enable`      | Enable a service for external connection to Gateway | `false`     |
-| `service.external.type`        | Type of load balancer                               | `ClusterIP` |
-| `service.external.ip`          | IP to configure                                     | `""`        |
-| `service.external.annotations` |                                                     | `{}`        |
-| `service.external.labels`      | Labels to be added to Gateway internal service      | `{}`        |
-| `service.external.admin`       | Enable admin exposition on external service         | `false`     |
-| `service.external.jmx`         | Enable jmx exposition on external service           | `false`     |
+| Name                           | Description                                              | Value       |
+| ------------------------------ | -------------------------------------------------------- | ----------- |
+| `service.external.enable`      | Enable a service for external connection to Gateway      | `false`     |
+| `service.external.type`        | Type of load balancer                                    | `ClusterIP` |
+| `service.external.ip`          | IP to configure                                          | `""`        |
+| `service.external.annotations` |                                                          | `{}`        |
+| `service.external.labels`      | Labels to be added to Gateway internal service           | `{}`        |
+| `service.external.admin`       | Enable admin exposition on external service              | `false`     |
+| `service.external.jmx`         | Enable jmx exposition on external service                | `false`     |
+| `service.external.extraSpecs`  | Extra specs for the service to be added under `spec` key | `{}`        |
 
 ### Conduktor-gateway internal service configurations
 
 This section specify internal service configuration
 
-| Name                           | Description                                    | Value |
-| ------------------------------ | ---------------------------------------------- | ----- |
-| `service.internal.annotations` |                                                | `{}`  |
-| `service.internal.labels`      | Labels to be added to Gateway internal service | `{}`  |
+| Name                           | Description                                              | Value |
+| ------------------------------ | -------------------------------------------------------- | ----- |
+| `service.internal.annotations` |                                                          | `{}`  |
+| `service.internal.labels`      | Labels to be added to Gateway internal service           | `{}`  |
+| `service.internal.extraSpecs`  | Extra specs for the service to be added under `spec` key | `{}`  |
 
 ### Gateway ingress configurations
 

--- a/charts/gateway/ci/02-gateway-with-selfSigned-ingress-values.yaml
+++ b/charts/gateway/ci/02-gateway-with-selfSigned-ingress-values.yaml
@@ -8,6 +8,17 @@ gateway:
   env:
     KAFKA_BOOTSTRAP_SERVERS: kafka.default.svc.cluster.local:9092
 
+service:
+  external:
+    enable: true
+    type: LoadBalancer
+    admin: true
+    extraSpecs:
+      externalTrafficPolicy: Local
+
+  internal:
+    extraSpecs:
+      trafficDistribution: PreferClose
 
 ingress:
   enabled: true

--- a/charts/gateway/templates/service-external.yaml
+++ b/charts/gateway/templates/service-external.yaml
@@ -23,6 +23,9 @@ spec:
   {{- if .Values.service.external.ip }}
   loadBalancerIP: {{ .Values.service.external.ip }}
   {{- end }}
+  {{- if .Values.service.external.extraSpecs }}
+  {{- include "common.tplvalues.render" (dict "value" .Values.service.external.extraSpecs "context" $) | nindent 2 }}
+  {{- end }}
   ports:
     {{- range untilStep (int .Values.gateway.portRange.start) (int (add .Values.gateway.portRange.start .Values.gateway.portRange.count)) 1 }}
     - name: broker-gateway-{{ . }}

--- a/charts/gateway/templates/service-internal.yaml
+++ b/charts/gateway/templates/service-internal.yaml
@@ -22,6 +22,9 @@ metadata:
   {{- end }}
 spec:
   type: ClusterIP
+  {{- if .Values.service.internal.extraSpecs }}
+  {{- include "common.tplvalues.render" (dict "value" .Values.service.internal.extraSpecs "context" $) | nindent 2 }}
+  {{- end }}
   ports:
     {{- range untilStep (int .Values.gateway.portRange.start) (int (add .Values.gateway.portRange.start .Values.gateway.portRange.count)) 1 }}
     - name: broker-gateway-{{ . }}

--- a/charts/gateway/values.yaml
+++ b/charts/gateway/values.yaml
@@ -291,6 +291,11 @@ service:
     admin: false
     ## @param service.external.jmx Enable jmx exposition on external service
     jmx: false
+    ## @param service.external.extraSpecs Extra specs for the service to be added under `spec` key
+    ## ref https://kubernetes.io/docs/reference/kubernetes-api/service-resources/service-v1/#ServiceSpec
+    ## extraSpecs:
+    ##   externalTrafficPolicy: Local
+    extraSpecs: {}
   ## @section Conduktor-gateway internal service configurations
   ## @descriptionStart
   ## This section specify internal service configuration
@@ -300,6 +305,11 @@ service:
     annotations: {}
     ## @param service.internal.labels Labels to be added to Gateway internal service
     labels: {}
+    ## @param service.internal.extraSpecs Extra specs for the service to be added under `spec` key
+    ## ref https://kubernetes.io/docs/reference/kubernetes-api/service-resources/service-v1/#ServiceSpec
+    ## extraSpecs:
+    ##   trafficDistribution: "PreferClose"
+    extraSpecs: {}
 
 ## @section Gateway ingress configurations
 ## @descriptionStart


### PR DESCRIPTION
Add `service.external.extraSpecs` and `service.internal.extraSpecs` to extend Internal and External Gateway services