### PR TITLE
Cus 912 helm chart kafkasql configuration cannot be disabled

### DIFF
--- a/charts/console/templates/_helpers.tpl
+++ b/charts/console/templates/_helpers.tpl
@@ -45,7 +45,7 @@ Return the full configuration for the platform ConfigMap
 {{- $_ := set $config "database" $database -}}
 
 {{/* Sanitize kafka sql database object if exist */}}
-{{- if and (hasKey .Values.config "kafkasql") (hasKey .Values.config.kafkasql "database") -}}
+{{- if and .Values.config.kafkasql .Values.config.kafkasql.database -}}
   {{- $kafkaSql := .Values.config.kafkasql | deepCopy -}}
   {{- $kafkaSqlDb := .Values.config.kafkasql.database | deepCopy -}}
   {{- include "conduktor.sanitize.database" (dict "database" $kafkaSqlDb) -}}

--- a/charts/console/templates/console/secret-credentials.yaml
+++ b/charts/console/templates/console/secret-credentials.yaml
@@ -26,12 +26,12 @@ data:
   CDK_DATABASE_USERNAME: {{ .Values.config.database.username | b64enc }}
   {{- end }}
 
-  {{- if and (hasKey .Values.config "kafkasql") (hasKey  .Values.config.kafkasql "database") -}}
+  {{- if and .Values.config.kafkasql .Values.config.kafkasql.database -}}
   {{- if .Values.config.kafkasql.database.url }}
   CDK_KAFKASQL_DATABASE_URL: {{ .Values.config.kafkasql.database.url | b64enc }}
   {{- else if and .Values.config.kafkasql.database.password .Values.config.kafkasql.database.username }}
-  CDK_KAFKASQL_DATABASE_USERNAME: {{ .Values.config.kafkasql.database.password | b64enc }}
-  CDK_KAFKASQL_DATABASE_PASSWORD: {{ .Values.config.kafkasql.database.username | b64enc }}
+  CDK_KAFKASQL_DATABASE_USERNAME: {{ .Values.config.kafkasql.database.username | b64enc }}
+  CDK_KAFKASQL_DATABASE_PASSWORD: {{ .Values.config.kafkasql.database.password | b64enc }}
   {{- end }}
   {{- end }}
 


### PR DESCRIPTION
REWE reported they are still unable to hide the SQL (preview) tab.

PR #260 fixed the kafkasql nil-check crash and swapped credentials in secret-credentials.yaml, but the identical buggy pattern was missed in _helpers.tpl:48 (the conduktor.platform.config helper that renders themain ConfigMap).

When kafkasql is omitted from values, Go template and evaluates all arguments without short-circuiting — hasKey receives a nil map and errors with wrong type for value; expected map[string]interface {}; got interface {}. This means customers still cannot omit kafkasql from their values, and the SQL (preview) tab cannot be hidden.

Change

Replaced hasKey checks with truthiness checks in _helpers.tpl:48, mirroring exactly what #260 did in secret-credentials.yaml:

 ```
 - {{- if and (hasKey .Values.config "kafkasql") (hasKey .Values.config.kafkasql "database") -}}
  + {{- if and .Values.config.kafkasql .Values.config.kafkasql.database -}}
```
