### PR TITLE
Add chart annotations for artifacthub.io

### DIFF
--- a/charts/console/Chart.yaml
+++ b/charts/console/Chart.yaml
@@ -18,3 +18,27 @@ dependencies:
       - bitnami-common
     # force version to avoid breaking changes due to remove support for older k8s versions in common chart v2.31.0 and above
     version: 2.30.2
+annotations:
+  artifacthub.io/license: Apache-2.0
+  artifacthub.io/category: streaming-messaging
+  artifacthub.io/images: |
+    - name: conduktor-console
+      image: conduktor/conduktor-console:1.45.0
+      platforms:
+        - linux/amd64
+        - linux/arm64
+    - name: conduktor-console-cortex
+      image: conduktor/conduktor-console-cortex:1.45.0
+      platforms:
+        - linux/amd64
+        - linux/arm64
+  artifacthub.io/links: |
+    - name: Changelog
+      url: https://docs.conduktor.io/guide/release-notes#console-1-45-0
+    - name: Documentation
+      url: https://docs.conduktor.io 
+    - name: support
+      url: https://www.conduktor.io/contact/support
+  artifacthub.io/screenshots: |
+    - title: Deployment architecture
+      url: https://docs.conduktor.io/images/deployment-overview.png

--- a/charts/console/Chart.yaml
+++ b/charts/console/Chart.yaml
@@ -36,7 +36,7 @@ annotations:
     - name: Changelog
       url: https://docs.conduktor.io/guide/release-notes#console-1-45-0
     - name: Documentation
-      url: https://docs.conduktor.io 
+      url: https://docs.conduktor.io
     - name: support
       url: https://www.conduktor.io/contact/support
   artifacthub.io/screenshots: |

--- a/charts/gateway/Chart.yaml
+++ b/charts/gateway/Chart.yaml
@@ -25,7 +25,7 @@ annotations:
     - name: Changelog
       url: https://docs.conduktor.io/guide/release-notes#gateway-3--0
     - name: Documentation
-      url: https://docs.conduktor.io 
+      url: https://docs.conduktor.io
     - name: support
       url: https://www.conduktor.io/contact/support
   artifacthub.io/screenshots: |

--- a/charts/gateway/Chart.yaml
+++ b/charts/gateway/Chart.yaml
@@ -12,3 +12,22 @@ dependencies:
     repository: https://charts.bitnami.com/bitnami
     tags:
       - bitnami-common
+annotations:
+  artifacthub.io/license: Apache-2.0
+  artifacthub.io/category: streaming-messaging
+  artifacthub.io/images: |
+    - name: conduktor-gateway
+      image: conduktor/conduktor-gateway:3.19.0
+      platforms:
+        - linux/amd64
+        - linux/arm64
+  artifacthub.io/links: |
+    - name: Changelog
+      url: https://docs.conduktor.io/guide/release-notes#gateway-3--0
+    - name: Documentation
+      url: https://docs.conduktor.io 
+    - name: support
+      url: https://www.conduktor.io/contact/support
+  artifacthub.io/screenshots: |
+    - title: Deployment architecture
+      url: https://docs.conduktor.io/images/deployment-overview.png

--- a/charts/provisioner/Chart.yaml
+++ b/charts/provisioner/Chart.yaml
@@ -31,7 +31,7 @@ annotations:
     - name: Changelog
       url: https://docs.conduktor.io/guide/release-notes
     - name: Documentation
-      url: https://docs.conduktor.io 
+      url: https://docs.conduktor.io
     - name: support
       url: https://www.conduktor.io/contact/support
   artifacthub.io/screenshots: |

--- a/charts/provisioner/Chart.yaml
+++ b/charts/provisioner/Chart.yaml
@@ -18,3 +18,22 @@ dependencies:
     tags:
       - bitnami-common
     version: 2.x.x
+annotations:
+  artifacthub.io/license: Apache-2.0
+  artifacthub.io/category: streaming-messaging
+  artifacthub.io/images: |
+    - name: conduktor-ctl
+      image: conduktor/conduktor-ctl:v0.7.0
+      platforms:
+        - linux/amd64
+        - linux/arm64
+  artifacthub.io/links: |
+    - name: Changelog
+      url: https://docs.conduktor.io/guide/release-notes
+    - name: Documentation
+      url: https://docs.conduktor.io 
+    - name: support
+      url: https://www.conduktor.io/contact/support
+  artifacthub.io/screenshots: |
+    - title: Deployment architecture
+      url: https://docs.conduktor.io/images/deployment-overview.png

--- a/charts/provisioner/ci/test-config.yaml
+++ b/charts/provisioner/ci/test-config.yaml
@@ -69,6 +69,7 @@ dependencies:
           GATEWAY_SECURITY_PROTOCOL: "SASL_PLAINTEXT"
           GATEWAY_ACL_ENABLED: "true"
           GATEWAY_SUPER_USERS: "admin"
+          GATEWAY_LICENSE_KEY: "${CDK_LICENSE}"
         admin:
           users:
             - username: admin


### PR DESCRIPTION
Add artifacthub.io specific [annotations](https://github.com/artifacthub/hub/blob/master/docs/helm_annotations.md) to add more details to chart artifacthub pages 