### PR TITLE
fix(console): make kafkasql guards safe on pre-Go-1.18 Helm

### DIFF
--- a/charts/console/templates/_helpers.tpl
+++ b/charts/console/templates/_helpers.tpl
@@ -45,12 +45,14 @@ Return the full configuration for the platform ConfigMap
 {{- $_ := set $config "database" $database -}}
 
 {{/* Sanitize kafka sql database object if exist */}}
-{{- if and .Values.config.kafkasql .Values.config.kafkasql.database -}}
+{{- if .Values.config.kafkasql -}}
+{{- if .Values.config.kafkasql.database -}}
   {{- $kafkaSql := .Values.config.kafkasql | deepCopy -}}
   {{- $kafkaSqlDb := .Values.config.kafkasql.database | deepCopy -}}
   {{- include "conduktor.sanitize.database" (dict "database" $kafkaSqlDb) -}}
   {{- $_ := set $kafkaSql "database" $kafkaSqlDb -}}
   {{- $_ := set $config "kafkasql" $kafkaSql -}}
+{{- end -}}
 {{- end -}}
 
 {{/* Render templates in values */}}

--- a/charts/console/templates/console/secret-credentials.yaml
+++ b/charts/console/templates/console/secret-credentials.yaml
@@ -26,12 +26,14 @@ data:
   CDK_DATABASE_USERNAME: {{ .Values.config.database.username | b64enc }}
   {{- end }}
 
-  {{- if and .Values.config.kafkasql .Values.config.kafkasql.database -}}
+  {{- if .Values.config.kafkasql -}}
+  {{- if .Values.config.kafkasql.database -}}
   {{- if .Values.config.kafkasql.database.url }}
   CDK_KAFKASQL_DATABASE_URL: {{ .Values.config.kafkasql.database.url | b64enc }}
   {{- else if and .Values.config.kafkasql.database.password .Values.config.kafkasql.database.username }}
   CDK_KAFKASQL_DATABASE_USERNAME: {{ .Values.config.kafkasql.database.username | b64enc }}
   CDK_KAFKASQL_DATABASE_PASSWORD: {{ .Values.config.kafkasql.database.password | b64enc }}
+  {{- end }}
   {{- end }}
   {{- end }}
 


### PR DESCRIPTION
PRs #260 and #266 rely on the and function short-circuiting in text/template. Go's and short-circuits only since Go 1.18 (March 2022), which means only Helm >= 3.9. The chart README documents a minimum of Helm 3.2.0+, so users in the 3.2.x - 3.8.x range satisfy the stated prerequisite but still hit:

    Error: UPGRADE FAILED: template: console/templates/console/
    secret-credentials.yaml:29:44: executing ... at
    <.Values.config.kafkasql.database>:
    nil pointer evaluating interface {}.database

when they omit kafkasql from their values.

Replace the two `and a b` guards with nested ifs so nil-safety no longer depends on the runtime's short-circuit behaviour. Preserves the README's 3.2.0+ promise and is defensive against any older Helm in the field.

Behaviour verified with helm template on chart 1.30.0 + Helm 4.1.4: kafkasql omitted, kafkasql: null, kafkasql: {}, and the kafkasql.database.url workaround all render as before (no CDK_KAFKASQL_* when disabled, the URL when set).