### PR TITLE
Added Gateway charts to help investigate latency issue

### DIFF
--- a/charts/gateway/grafana-dashboards/gateway.json
+++ b/charts/gateway/grafana-dashboards/gateway.json
@@ -1220,6 +1220,98 @@
       "type": "timeseries"
     },
     {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "P99 request-response latency per Gateway pod. Identifies uneven load distribution.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 1,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 8,
+        "x": 16,
+        "y": 18
+      },
+      "id": 529,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, rate(gateway_latency_request_response_seconds_bucket{job=\"$job\", pod=~\"$pod\"}[$__rate_interval]))",
+          "legendFormat": "{{pod}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "P99 Latency per Pod",
+      "type": "timeseries"
+    },
+    {
       "collapsed": false,
       "gridPos": {
         "h": 1,
@@ -1481,12 +1573,432 @@
       "type": "timeseries"
     },
     {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Average latency per Kafka API key. Identifies which operations contribute most to overall latency.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 1,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": [
+          {
+            "__systemRef": "hideSeriesFrom",
+            "matcher": {
+              "id": "byNames",
+              "options": {
+                "mode": "exclude",
+                "names": [
+                  "Fetch",
+                  "Produce"
+                ],
+                "prefix": "All except:",
+                "readOnly": true
+              }
+            },
+            "properties": [
+              {
+                "id": "custom.hideFrom",
+                "value": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": true
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 12,
+        "x": 0,
+        "y": 38
+      },
+      "id": 530,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum by(apiKeys) (rate(gateway_apiKeys_latency_request_response_seconds_sum{job=\"$job\", pod=~\"$pod\"}[$__rate_interval])) / sum by(apiKeys) (rate(gateway_apiKeys_latency_request_response_seconds_count{job=\"$job\", pod=~\"$pod\"}[$__rate_interval]))",
+          "legendFormat": "{{apiKeys}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Avg Latency / API key",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Maximum latency per Kafka API key. Shows worst-case latency, identifies P99 contributors.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 1,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": [
+          {
+            "__systemRef": "hideSeriesFrom",
+            "matcher": {
+              "id": "byNames",
+              "options": {
+                "mode": "exclude",
+                "names": [
+                  "Fetch",
+                  "Produce"
+                ],
+                "prefix": "All except:",
+                "readOnly": true
+              }
+            },
+            "properties": [
+              {
+                "id": "custom.hideFrom",
+                "value": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": true
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 12,
+        "x": 12,
+        "y": 38
+      },
+      "id": 531,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "max by(apiKeys) (gateway_apiKeys_latency_request_response_seconds_max{job=\"$job\", pod=~\"$pod\"})",
+          "legendFormat": "{{apiKeys}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Max Latency / API key",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Max I/O wait time per pod. High values indicate backend Kafka is slow to respond.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 1,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 12,
+        "x": 0,
+        "y": 48
+      },
+      "id": 532,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "max by(pod) (gateway_upstream_io_wait_rate_seconds_max{job=\"$job\", pod=~\"$pod\"})",
+          "legendFormat": "{{pod}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Upstream IO Wait (Backend Kafka Latency Proxy)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Pending tasks on Gateway threads. High values indicate Gateway is backed up.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 1,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 12,
+        "x": 12,
+        "y": 48
+      },
+      "id": 533,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum by(pod) (gateway_thread_tasks{job=\"$job\", pod=~\"$pod\"})",
+          "legendFormat": "{{pod}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Pending Thread Tasks",
+      "type": "timeseries"
+    },
+    {
       "collapsed": false,
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 38
+        "y": 58
       },
       "id": 517,
       "panels": [],
@@ -1558,7 +2070,7 @@
         "h": 9,
         "w": 12,
         "x": 0,
-        "y": 39
+        "y": 59
       },
       "id": 436,
       "options": {
@@ -1655,7 +2167,7 @@
         "h": 9,
         "w": 12,
         "x": 12,
-        "y": 39
+        "y": 59
       },
       "id": 254,
       "options": {
@@ -1700,7 +2212,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 48
+        "y": 68
       },
       "id": 524,
       "panels": [],
@@ -1772,7 +2284,7 @@
         "h": 11,
         "w": 12,
         "x": 0,
-        "y": 49
+        "y": 69
       },
       "id": 525,
       "options": {
@@ -1817,7 +2329,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 60
+        "y": 80
       },
       "id": 527,
       "panels": [],
@@ -1889,7 +2401,7 @@
         "h": 9,
         "w": 12,
         "x": 0,
-        "y": 61
+        "y": 81
       },
       "id": 528,
       "options": {
@@ -1931,7 +2443,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 70
+        "y": 90
       },
       "id": 34,
       "panels": [],
@@ -2085,7 +2597,7 @@
         "h": 10,
         "w": 12,
         "x": 0,
-        "y": 71
+        "y": 91
       },
       "id": 33,
       "interval": "1m",
@@ -2307,7 +2819,7 @@
         "h": 10,
         "w": 12,
         "x": 12,
-        "y": 71
+        "y": 91
       },
       "id": 41,
       "interval": "1m",
@@ -2383,7 +2895,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 81
+        "y": 101
       },
       "id": 108,
       "panels": [
@@ -2408,7 +2920,7 @@
             "h": 7,
             "w": 8,
             "x": 0,
-            "y": 82
+            "y": 102
           },
           "hiddenSeries": false,
           "id": 24,
@@ -2541,7 +3053,7 @@
             "h": 7,
             "w": 8,
             "x": 8,
-            "y": 82
+            "y": 102
           },
           "hiddenSeries": false,
           "id": 25,
@@ -2675,7 +3187,7 @@
             "h": 7,
             "w": 8,
             "x": 16,
-            "y": 82
+            "y": 102
           },
           "hiddenSeries": false,
           "id": 26,
@@ -2892,7 +3404,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 82
+        "y": 102
       },
       "id": 109,
       "panels": [
@@ -2917,7 +3429,7 @@
             "h": 7,
             "w": 6,
             "x": 0,
-            "y": 14
+            "y": 34
           },
           "hiddenSeries": false,
           "id": 106,
@@ -3056,7 +3568,7 @@
             "h": 7,
             "w": 6,
             "x": 6,
-            "y": 14
+            "y": 34
           },
           "hiddenSeries": false,
           "id": 93,
@@ -3178,7 +3690,7 @@
             "h": 7,
             "w": 6,
             "x": 12,
-            "y": 14
+            "y": 34
           },
           "hiddenSeries": false,
           "id": 32,
@@ -3336,7 +3848,7 @@
             "h": 7,
             "w": 6,
             "x": 18,
-            "y": 14
+            "y": 34
           },
           "hiddenSeries": false,
           "id": 61,
@@ -3454,7 +3966,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 83
+        "y": 103
       },
       "id": 110,
       "panels": [
@@ -3479,7 +3991,7 @@
             "h": 7,
             "w": 8,
             "x": 0,
-            "y": 15
+            "y": 35
           },
           "hiddenSeries": false,
           "id": 3,
@@ -3623,7 +4135,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 84
+        "y": 104
       },
       "id": 111,
       "panels": [
@@ -3648,7 +4160,7 @@
             "h": 7,
             "w": 8,
             "x": 0,
-            "y": 16
+            "y": 36
           },
           "hiddenSeries": false,
           "id": 78,
@@ -3791,7 +4303,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 85
+        "y": 105
       },
       "id": 112,
       "panels": [
@@ -3859,7 +4371,7 @@
             "h": 7,
             "w": 8,
             "x": 0,
-            "y": 17
+            "y": 37
           },
           "id": 98,
           "links": [],
@@ -3924,7 +4436,7 @@
             "h": 7,
             "w": 8,
             "x": 8,
-            "y": 17
+            "y": 37
           },
           "hiddenSeries": false,
           "id": 101,
@@ -4058,7 +4570,7 @@
             "h": 7,
             "w": 8,
             "x": 16,
-            "y": 17
+            "y": 37
           },
           "hiddenSeries": false,
           "id": 99,
@@ -4165,7 +4677,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 86
+        "y": 106
       },
       "id": 113,
       "panels": [
@@ -4190,7 +4702,7 @@
             "h": 7,
             "w": 12,
             "x": 0,
-            "y": 18
+            "y": 38
           },
           "hiddenSeries": false,
           "id": 37,
@@ -4297,7 +4809,7 @@
             "h": 7,
             "w": 12,
             "x": 12,
-            "y": 18
+            "y": 38
           },
           "hiddenSeries": false,
           "id": 38,
@@ -4431,7 +4943,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 87
+        "y": 107
       },
       "id": 114,
       "panels": [
@@ -4456,7 +4968,7 @@
             "h": 7,
             "w": 6,
             "x": 0,
-            "y": 19
+            "y": 39
           },
           "hiddenSeries": false,
           "id": 518,
@@ -4578,7 +5090,7 @@
             "h": 7,
             "w": 6,
             "x": 6,
-            "y": 19
+            "y": 39
           },
           "hiddenSeries": false,
           "id": 83,
@@ -4686,7 +5198,7 @@
             "h": 7,
             "w": 6,
             "x": 12,
-            "y": 19
+            "y": 39
           },
           "hiddenSeries": false,
           "id": 85,
@@ -4808,7 +5320,7 @@
             "h": 7,
             "w": 6,
             "x": 18,
-            "y": 19
+            "y": 39
           },
           "hiddenSeries": false,
           "id": 84,
@@ -4909,7 +5421,12 @@
   "refresh": "30s",
   "schemaVersion": 37,
   "style": "dark",
-  "tags": ["Conduktor", "conduktor-gateway", "JVM", "Pod"],
+  "tags": [
+    "Conduktor",
+    "conduktor-gateway",
+    "JVM",
+    "Pod"
+  ],
   "templating": {
     "list": [
       {


### PR DESCRIPTION
To help investigating the cause of high "Total Requests Latency", this PR adds the following panels to Gateway Grafana dashboard:

- Kafka gateway section:
  - P99 Latency per Pod: per-pod P99 latency histogram
- Per ApiKey section:
  - Avg Latency / API key: rate(sum)/rate(count) per API key
  - Max Latency / API key: worst-case latency per API key
  - Upstream IO Wait: backend Kafka response time proxy
  - Pending Thread Tasks: detects Gateway thread backpressure

<img width="1916" height="724" alt="image" src="https://github.com/user-attachments/assets/cfc004af-18fa-4815-91e6-581ffb743b72" />

<img width="1916" height="918" alt="image" src="https://github.com/user-attachments/assets/39dbfefe-85f0-4187-b55f-3aaf57b65efd" />
