### PR TITLE
Fix Gateway GATEWAY_LISTENER_*_ADVERTISED_HOST env var

### DIFF
--- a/charts/gateway/templates/_helpers.tpl
+++ b/charts/gateway/templates/_helpers.tpl
@@ -622,7 +622,7 @@ Go template iterates JSON object keys in sorted order — output is deterministi
   {{- $_ := set $vars "GATEWAY_LISTENER_EXTERNAL_SECURITY_PROTOCOL" .Values.gateway.listeners.external.securityProtocol -}}
   {{- $_ := set $vars "GATEWAY_LISTENER_EXTERNAL_ROUTING" (.Values.gateway.listeners.external.routing | upper) -}}
   {{- $_ := set $vars "GATEWAY_LISTENER_EXTERNAL_PORTS" (.Values.gateway.listeners.external.ports | join ",") -}}
-  {{- $_ := set $vars "GATEWAY_LISTENER_EXTERNAL_HOST" .Values.gateway.listeners.external.advertisedHost -}}
+  {{- $_ := set $vars "GATEWAY_LISTENER_EXTERNAL_ADVERTISED_HOST" .Values.gateway.listeners.external.advertisedHost -}}
   {{- if .Values.gateway.listeners.external.advertisedHostPattern -}}
     {{- $_ := set $vars "GATEWAY_LISTENER_EXTERNAL_ADVERTISED_HOST_PATTERN" .Values.gateway.listeners.external.advertisedHostPattern -}}
   {{- end -}}

--- a/charts/gateway/templates/_helpers.tpl
+++ b/charts/gateway/templates/_helpers.tpl
@@ -610,7 +610,7 @@ Go template iterates JSON object keys in sorted order — output is deterministi
 {{- $_ := set $vars "GATEWAY_LISTENER_INTERNAL_SECURITY_PROTOCOL" .Values.gateway.listeners.internal.securityProtocol -}}
 {{- $_ := set $vars "GATEWAY_LISTENER_INTERNAL_ROUTING" (.Values.gateway.listeners.internal.routing | upper) -}}
 {{- $_ := set $vars "GATEWAY_LISTENER_INTERNAL_PORTS" (.Values.gateway.listeners.internal.ports | join ",") -}}
-{{- $_ := set $vars "GATEWAY_LISTENER_INTERNAL_HOST" (include "conduktor-gateway.internalListenerAdvertisedHost" .) -}}
+{{- $_ := set $vars "GATEWAY_LISTENER_INTERNAL_ADVERTISED_HOST" (include "conduktor-gateway.internalListenerAdvertisedHost" .) -}}
 {{- if eq .Values.gateway.listeners.internal.routing "sni" -}}
   {{- $_ := set $vars "GATEWAY_LISTENER_INTERNAL_ADVERTISED_HOST_PATTERN" (include "conduktor-gateway.internalSNIAdvertisedHostPattern" .) -}}
   {{- $_ := set $vars "GATEWAY_LISTENER_INTERNAL_BOOTSTRAP_HOST_PATTERN" (include "conduktor-gateway.internalListenerAdvertisedHost" .) -}}


### PR DESCRIPTION
Fix typo in Conduktor Gateway internal listener env var `GATEWAY_LISTENER_INTERNAL_ADVERTISED_HOST` and `GATEWAY_LISTENER_EXTERNAL_ADVERTISED_HOST`.
Fix #284 