### PR TITLE
Move truststore mount to dedicated folder /etc/gateway/truststore

### DIFF
--- a/charts/gateway/README.md
+++ b/charts/gateway/README.md
@@ -677,7 +677,7 @@ gateway:
           path: kafka.truststore.jks
   volumeMounts:
     - name: truststore
-      mountPath: /etc/gateway/tls/truststore/
+      mountPath: /etc/gateway/truststore/
       readOnly: true
 ```
 
@@ -685,7 +685,7 @@ Finally, we can configure our truststore location
 ```yaml
 gateway:
   env:
-    KAFKA_SSL_TRUSTSTORE_LOCATION: /etc/gateway/tls/truststore/kafka.truststore.jks
+    KAFKA_SSL_TRUSTSTORE_LOCATION: /etc/gateway/truststore/kafka.truststore.jks
 ```
 
 ### Set Gateway Container and Pod Security Context

--- a/charts/gateway/templates/_helpers.tpl
+++ b/charts/gateway/templates/_helpers.tpl
@@ -267,7 +267,7 @@ Returns JSON.
   {{- end -}}
 {{- end -}}
 {{- if .Values.tls.truststore.secretRef -}}
-  {{- $_ := set $vars "GATEWAY_SSL_TRUST_STORE_PATH" (printf "/etc/gateway/tls/%s" .Values.tls.truststore.keystoreFile) -}}
+  {{- $_ := set $vars "GATEWAY_SSL_TRUST_STORE_PATH" (printf "/etc/gateway/truststore/%s" .Values.tls.truststore.keystoreFile) -}}
   {{- $_ := set $vars "GATEWAY_SSL_TRUST_STORE_TYPE" "jks" -}}
   {{- if .Values.tls.truststore.passwordSecretRef.name -}}
     {{- $tsPwKey := .Values.tls.truststore.passwordSecretRef.key | default "password" -}}

--- a/charts/gateway/templates/deployment.yaml
+++ b/charts/gateway/templates/deployment.yaml
@@ -139,8 +139,7 @@ spec:
             {{- end }}
             {{- if and .Values.tls.truststore.secretRef (not (and .Values.tls.certManager.enabled .Values.tls.certManager.truststore.enabled)) }}
             - name: truststore
-              mountPath: /etc/gateway/tls/{{ .Values.tls.truststore.keystoreFile }}
-              subPath: {{ .Values.tls.truststore.keystoreKey }}
+              mountPath: /etc/gateway/truststore/
               readOnly: true
             {{- end }}
             - name: config
@@ -217,6 +216,9 @@ spec:
         - name: truststore
           secret:
             secretName: {{ .Values.tls.truststore.secretRef }}
+            items:
+            - key: {{ .Values.tls.truststore.keystoreKey }}
+              path: {{ .Values.tls.truststore.keystoreFile }}
         {{- end }}
         - name: config
           configMap:


### PR DESCRIPTION
Avoid mount conflict with keystore and truststore files. 

Previously : 
```yaml
# keystore: mounts the WHOLE directory
- name: keystore
  mountPath: /etc/gateway/tls/
  readOnly: true
# truststore: mounts a FILE inside that same directory via subPath
- name: truststore
  mountPath: /etc/gateway/tls/truststore.jks
  subPath: truststore.jks
  readOnly: true
```

Now mount truststore to separated dedicated folder `/etc/gateway/truststore/ `and remove `subPath` :

```yaml
- name: keystore
  mountPath: /etc/gateway/tls/
  readOnly: true
- name: truststore
  mountPath: /etc/gateway/truststore/
  readOnly: true
```