### PR TITLE
feat(gateway): add service.internal.enable flag to conditionally suppress internal ClusterIP service

### DIFF
--- a/charts/gateway/README.md
+++ b/charts/gateway/README.md
@@ -224,11 +224,12 @@ This section specifies external service configuration
 
 This section specify internal service configuration
 
-| Name                           | Description                                              | Value |
-| ------------------------------ | -------------------------------------------------------- | ----- |
-| `service.internal.annotations` |                                                          | `{}`  |
-| `service.internal.labels`      | Labels to be added to Gateway internal service           | `{}`  |
-| `service.internal.extraSpecs`  | Extra specs for the service to be added under `spec` key | `{}`  |
+| Name                           | Description                                                                                                                                                                                   | Value  |
+| ------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------ |
+| `service.internal.enable`      | Enable the internal ClusterIP service. Set to false to suppress the service (e.g. for security hardening). When false, you must set GATEWAY_LISTENER_INTERNAL_ADVERTISED_HOST in gateway.env. | `true` |
+| `service.internal.annotations` |                                                                                                                                                                                               | `{}`   |
+| `service.internal.labels`      | Labels to be added to Gateway internal service                                                                                                                                                | `{}`   |
+| `service.internal.extraSpecs`  | Extra specs for the service to be added under `spec` key                                                                                                                                      | `{}`   |
 
 ### Gateway ingress configurations
 

--- a/charts/gateway/ci/11-gateway-no-internal-service-values.yaml
+++ b/charts/gateway/ci/11-gateway-no-internal-service-values.yaml
@@ -1,0 +1,42 @@
+nameOverride: gateway-test-11
+
+gateway:
+  replicas: 1
+  securityMode: "GATEWAY_MANAGED"
+  aclEnabled: "false"
+  listeners:
+    internal:
+      securityProtocol: PLAINTEXT
+      routing: port
+      ports:
+        - "19092-19098"
+  env:
+    KAFKA_BOOTSTRAP_SERVERS: kafka.ct-gateway-deps.svc.cluster.local:9092
+    GATEWAY_CLUSTER_ID: "gw-11"
+    GATEWAY_LISTENER_INTERNAL_ADVERTISED_HOST: "my-custom-internal-host.example.com"
+  extraSecretEnvVars:
+    - name: GATEWAY_LICENSE_KEY
+      valueFrom:
+        secretKeyRef:
+          name: gateway-license
+          key: GATEWAY_LICENSE_KEY
+  securityContext:
+    capabilities:
+      drop:
+        - ALL
+    readOnlyRootFilesystem: true
+    runAsNonRoot: true
+    runAsUser: 1000
+  volumes:
+    - name: tmp
+      emptyDir: {}
+  volumeMounts:
+    - name: tmp
+      mountPath: /tmp
+
+service:
+  internal:
+    enable: false
+
+podSecurityContext:
+  runAsNonRoot: true

--- a/charts/gateway/templates/NOTES.txt
+++ b/charts/gateway/templates/NOTES.txt
@@ -64,9 +64,11 @@ Admin API :
 {{- $proto := ternary "https" "http" .Values.ingress.tls }}
   External access : {{ printf "%s://%s" $proto .Values.ingress.hostname }}
 {{- end }}
+{{- if .Values.service.internal.enable }}
   Internal access : {{ $internalServiceHost }}:{{ .Values.gateway.admin.port }}.
   It could be exposed outside using a port-forwarding or a LoadBalancer like and be available at http://127.0.0.1:{{ .Values.gateway.admin.port }}
     $ kubectl port-forward -n {{ .Release.Namespace }} svc/{{ include "conduktor-gateway.internalServiceName" . }} {{ .Values.gateway.admin.port }}:{{ .Values.gateway.admin.port }}
+{{- end }}
 {{- if and (not .Values.gateway.secretRef) .Values.gateway.admin.users }}
   Admin API credentials :
     ADMIN_LOGIN="$(kubectl get secret {{ include "conduktor-gateway.secretName" . }} -n {{ .Release.Namespace }} -o jsonpath="{.data.GATEWAY_ADMIN_API_USER_0_USERNAME}" | base64 --decode)"

--- a/charts/gateway/templates/_helpers.tpl
+++ b/charts/gateway/templates/_helpers.tpl
@@ -733,7 +733,7 @@ Accumulates all errors and fails once with a combined message.
 
 {{- /* Internal service disabled: user must supply GATEWAY_LISTENER_INTERNAL_ADVERTISED_HOST */ -}}
 {{- if not .Values.service.internal.enable -}}
-  {{- if not (hasKey .Values.gateway.env "GATEWAY_LISTENER_INTERNAL_ADVERTISED_HOST") -}}
+  {{- if eq (include "conduktor-gateway.envExists" (dict "envkey" "GATEWAY_LISTENER_INTERNAL_ADVERTISED_HOST" "context" $)) "false" -}}
     {{- $errors = append $errors "- service.internal.enable is false but GATEWAY_LISTENER_INTERNAL_ADVERTISED_HOST is not set in gateway.env. Set it to the hostname Kafka clients should use to reach the internal listener." -}}
   {{- end -}}
 {{- end -}}

--- a/charts/gateway/templates/_helpers.tpl
+++ b/charts/gateway/templates/_helpers.tpl
@@ -641,10 +641,12 @@ Go template iterates JSON object keys in sorted order — output is deterministi
 {{- $_ := set $vars "GATEWAY_LISTENER_INTERNAL_SECURITY_PROTOCOL" .Values.gateway.listeners.internal.securityProtocol -}}
 {{- $_ := set $vars "GATEWAY_LISTENER_INTERNAL_ROUTING" (.Values.gateway.listeners.internal.routing | upper) -}}
 {{- $_ := set $vars "GATEWAY_LISTENER_INTERNAL_PORTS" (.Values.gateway.listeners.internal.ports | join ",") -}}
-{{- $_ := set $vars "GATEWAY_LISTENER_INTERNAL_ADVERTISED_HOST" (include "conduktor-gateway.internalListenerAdvertisedHost" .) -}}
-{{- if eq .Values.gateway.listeners.internal.routing "sni" -}}
-  {{- $_ := set $vars "GATEWAY_LISTENER_INTERNAL_ADVERTISED_HOST_PATTERN" (include "conduktor-gateway.internalSNIAdvertisedHostPattern" .) -}}
-  {{- $_ := set $vars "GATEWAY_LISTENER_INTERNAL_BOOTSTRAP_HOST_PATTERN" (include "conduktor-gateway.internalListenerAdvertisedHost" .) -}}
+{{- if .Values.service.internal.enable -}}
+  {{- $_ := set $vars "GATEWAY_LISTENER_INTERNAL_ADVERTISED_HOST" (include "conduktor-gateway.internalListenerAdvertisedHost" .) -}}
+  {{- if eq .Values.gateway.listeners.internal.routing "sni" -}}
+    {{- $_ := set $vars "GATEWAY_LISTENER_INTERNAL_ADVERTISED_HOST_PATTERN" (include "conduktor-gateway.internalSNIAdvertisedHostPattern" .) -}}
+    {{- $_ := set $vars "GATEWAY_LISTENER_INTERNAL_BOOTSTRAP_HOST_PATTERN" (include "conduktor-gateway.internalListenerAdvertisedHost" .) -}}
+  {{- end -}}
 {{- end -}}
 {{- if and .Values.gateway.listeners.internal.sslClientAuth (has .Values.gateway.listeners.internal.securityProtocol (list "SSL" "SASL_SSL")) -}}
   {{- $_ := set $vars "GATEWAY_LISTENER_INTERNAL_SSL_CLIENT_AUTH" .Values.gateway.listeners.internal.sslClientAuth -}}
@@ -727,6 +729,18 @@ Accumulates all errors and fails once with a combined message.
 {{- /* External listener requires advertisedHost */ -}}
 {{- if and .Values.service.external.enable (empty .Values.gateway.listeners.external.advertisedHost) -}}
   {{- $errors = append $errors "- gateway.listeners.external.advertisedHost is required in multi-listener mode when service.external.enable is true." -}}
+{{- end -}}
+
+{{- /* Internal service disabled: user must supply GATEWAY_LISTENER_INTERNAL_ADVERTISED_HOST */ -}}
+{{- if not .Values.service.internal.enable -}}
+  {{- if not (hasKey .Values.gateway.env "GATEWAY_LISTENER_INTERNAL_ADVERTISED_HOST") -}}
+    {{- $errors = append $errors "- service.internal.enable is false but GATEWAY_LISTENER_INTERNAL_ADVERTISED_HOST is not set in gateway.env. Set it to the hostname Kafka clients should use to reach the internal listener." -}}
+  {{- end -}}
+{{- end -}}
+
+{{- /* Ingress routes to the internal service admin port — incompatible with service.internal.enable: false */ -}}
+{{- if and .Values.ingress.enabled (not .Values.service.internal.enable) -}}
+  {{- $errors = append $errors "- ingress.enabled requires service.internal.enable: true (ingress routes to the internal service admin port)." -}}
 {{- end -}}
 
 {{- /* Internal SNI requires brokerIds */ -}}

--- a/charts/gateway/templates/service-internal.yaml
+++ b/charts/gateway/templates/service-internal.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.service.internal.enable }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -53,3 +54,4 @@ spec:
       protocol: TCP
     {{- end }}
   selector: {{ include "conduktor-gateway.podSelectorLabels" . | nindent 4 }}
+{{- end }}

--- a/charts/gateway/templates/tests/health-check.yaml
+++ b/charts/gateway/templates/tests/health-check.yaml
@@ -5,6 +5,7 @@
 {{- $externalServiceName := include "conduktor-gateway.externalServiceName" . -}}
 {{- $externalServicePort := .Values.gateway.admin.port -}}
 {{- $externalHealthUrl := printf "%s://%v:%v/health" $apiScheme $externalServiceName $externalServicePort -}}
+{{- if or .Values.service.internal.enable .Values.service.external.enable }}
 apiVersion: v1
 kind: Pod
 metadata:
@@ -14,15 +15,17 @@ metadata:
     "helm.sh/hook-delete-policy": hook-succeeded
 spec:
   containers:
+{{- if .Values.service.internal.enable }}
     - name: curl-gateway-internal
       image: curlimages/curl:8.1.2
       args: [ '--insecure', "--verbose" ,'{{ $internalHealthUrl }}']
+{{- end }}
 {{- if and .Values.service.external.enable .Values.service.external.admin }}
     - name: curl-gateway-external
       image: curlimages/curl:8.1.2
       args: [ '--insecure', "--verbose" ,'{{ $externalHealthUrl }}']
 {{- end }}
-{{- if .Values.gateway.admin.users }}
+{{- if and .Values.service.internal.enable .Values.gateway.admin.users }}
 {{- $internalAdminApiVclusterUrl := printf "%s://%v:%v/gateway/v2/virtual-cluster" $apiScheme $internalServiceName $internalServicePort }}
 {{- $secretName := include "conduktor-gateway.secretName" . }}
 {{- $adminLogin := include "common.secrets.lookup" (dict "secret" $secretName "key" .Values.gateway.admin.mainAdminSecretKeys.username "defaultValue" "admin" "context" $) }}
@@ -34,3 +37,4 @@ spec:
               '--user', '{{ $adminLogin }}:{{ $adminPassword}}']
 {{- end }}
   restartPolicy: Never
+{{- end }}

--- a/charts/gateway/values.schema.json
+++ b/charts/gateway/values.schema.json
@@ -761,6 +761,11 @@
                 "internal": {
                     "type": "object",
                     "properties": {
+                        "enable": {
+                            "type": "boolean",
+                            "description": "Enable the internal ClusterIP service. Set to false to suppress the service (e.g. for security hardening). When false, you must set GATEWAY_LISTENER_INTERNAL_ADVERTISED_HOST in gateway.env.",
+                            "default": true
+                        },
                         "annotations": {
                             "type": "object",
                             "description": "",

--- a/charts/gateway/values.yaml
+++ b/charts/gateway/values.yaml
@@ -383,6 +383,8 @@ service:
   ## This section specify internal service configuration
   ## @descriptionEnd
   internal:
+    ## @param service.internal.enable Enable the internal ClusterIP service. Set to false to suppress the service (e.g. for security hardening). When false, you must set GATEWAY_LISTENER_INTERNAL_ADVERTISED_HOST in gateway.env.
+    enable: true
     ## @param service.internal.annotations
     annotations: {}
     ## @param service.internal.labels Labels to be added to Gateway internal service


### PR DESCRIPTION
## Summary

- Adds `service.internal.enable: true` (default) to the Gateway Helm chart, mirroring the existing `service.external.enable` pattern
- When set to `false`, the internal ClusterIP Service is not created — useful for security hardening when the internal Kafka listener is not needed
- Validation fails loudly if `GATEWAY_LISTENER_INTERNAL_ADVERTISED_HOST` is not supplied via `gateway.env` or `gateway.extraSecretEnvVars` when the service is disabled
- Validation also prevents enabling ingress while the internal service is disabled (ingress routes to the internal service admin port)

## Changes

| File | Change |
|------|--------|
| `values.yaml` | Add `service.internal.enable: true` |
| `values.schema.json` | Add `service.internal.enable` property |
| `templates/service-internal.yaml` | Wrap in `{{- if .Values.service.internal.enable }}` |
| `templates/_helpers.tpl` | Conditional `GATEWAY_LISTENER_INTERNAL_ADVERTISED_HOST` auto-derivation + two validation rules |
| `templates/tests/health-check.yaml` | Guard internal-service-dependent containers |
| `templates/NOTES.txt` | Guard internal admin access section |
| `ci/11-gateway-no-internal-service-values.yaml` | New CI values file exercising the `false` path |

## Usage

```yaml
service:
  internal:
    enable: false

gateway:
  env:
    GATEWAY_LISTENER_INTERNAL_ADVERTISED_HOST: "my-custom-host.example.com"
```

## Test plan

- [ ] `helm lint charts/gateway/` — 0 failures
- [ ] `helm lint charts/gateway/ -f charts/gateway/ci/11-gateway-no-internal-service-values.yaml` — 0 failures
- [ ] `helm template` with `service.internal.enable=false` produces no `kind: Service` matching `*-internal`
- [ ] `helm template` with `service.internal.enable=false` and no `GATEWAY_LISTENER_INTERNAL_ADVERTISED_HOST` fails with validation error
- [ ] `helm template` with `ingress.enabled=true` + `service.internal.enable=false` fails with validation error
- [ ] Default (`service.internal.enable` not set) is unchanged — internal service rendered as before