### PR TITLE
docs(console): add air-gapped deployment guide to chart README

### DIFF
--- a/charts/console/README.md
+++ b/charts/console/README.md
@@ -377,6 +377,7 @@ console, we recommend you to look at our
 - [Install with a Confluent Cloud cluster](#install-with-a-confluent-cloud-cluster)
 - [Install with an enterprise license](#install-with-an-enterprise-license)
 - [Install without Conduktor monitoring](#install-without-conduktor-monitoring)
+- [Install in an air-gapped environment](#install-in-an-air-gapped-environment)
 
 ### Kubernetes configuration
 - [Conduktor Console](#conduktor-console)
@@ -405,6 +406,7 @@ console, we recommend you to look at our
     - [Provide credentials configuration as a Kubernetes Secret](#provide-credentials-configuration-as-a-kubernetes-secret)
     - [Provide monitoring configuration as a Kubernetes Secret](#provide-monitoring-configuration-as-a-kubernetes-secret)
     - [Pulling from private registry using `global.imagePullSecrets`](#pulling-from-private-registry-using-globalimagepullsecrets)
+    - [Install in an air-gapped environment](#install-in-an-air-gapped-environment)
     - [Store platform data into a Persistent Volume](#store-platform-data-into-a-persistent-volume)
     - [Install with a PodAffinity](#install-with-a-podaffinity)
     - [Provide console configuration as a Kubernetes ConfigMap](#provide-console-configuration-as-a-kubernetes-configmap)
@@ -735,6 +737,63 @@ platformCortex:
     tag: nightly
     pullSecrets:
       - docker-regsitry-secret-cortex
+```
+
+### Install in an air-gapped environment
+
+To deploy Console in an environment without internet access, you need to complete the following steps on an internet-connected machine before deploying to the cluster.
+
+**1. Get the chart**
+
+Download the packaged chart from the [GitHub releases page](https://github.com/conduktor/conduktor-public-charts/releases) or pull it from the Helm repository:
+
+```sh
+helm repo add conduktor https://helm.conduktor.io
+helm repo update
+helm pull conduktor/console --version <version>
+```
+
+Both sources ship with all chart dependencies already bundled — no `helm dependency build` needed.
+
+**2. Repackage the chart for your private registry**
+
+Inject your private registry as the default and push the chart to your internal OCI registry:
+
+```sh
+# Set your private image registry as the default
+yq -i '.global.imageRegistry = "<your-private-registry>"' console/values.yaml
+
+# Repackage and push to your internal OCI registry
+tar czf console-<version>.tgz console/
+helm push console-<version>.tgz oci://<your-chart-registry>
+```
+
+**3. Mirror the Console images**
+
+Console uses two images. Pull each one from Docker Hub and push it to your private registry:
+
+```sh
+# Console
+docker pull conduktor/conduktor-console:<version>
+docker tag conduktor/conduktor-console:<version> <your-private-registry>/conduktor/conduktor-console:<version>
+docker push <your-private-registry>/conduktor/conduktor-console:<version>
+
+# Console Cortex (monitoring)
+docker pull conduktor/conduktor-console-cortex:<version>
+docker tag conduktor/conduktor-console-cortex:<version> <your-private-registry>/conduktor/conduktor-console-cortex:<version>
+docker push <your-private-registry>/conduktor/conduktor-console-cortex:<version>
+```
+
+The image tags follow the chart `appVersion`. If you disable the Cortex monitoring component, you can skip mirroring `conduktor-console-cortex`.
+
+**4. Set up registry authentication**
+
+Configure your cluster to authenticate to your private registry. The recommended approach is to use your cloud provider's native registry authentication (for example, IRSA on EKS) to avoid managing short-lived credentials. Alternatively, use `global.imagePullSecrets` — see [Pulling from private registry using `global.imagePullSecrets`](#pulling-from-private-registry-using-globalimagepullsecrets).
+
+**5. Install**
+
+```sh
+helm install my-console oci://<your-chart-registry>/console --version <version>
 ```
 
 ### Store platform data on a Persistent Volume

--- a/charts/console/README.md
+++ b/charts/console/README.md
@@ -741,7 +741,12 @@ platformCortex:
 
 ### Install in an air-gapped environment
 
-To deploy Console in an environment without internet access, you need to complete the following steps on an internet-connected machine before deploying to the cluster.
+To deploy Console in an environment without internet access, you can either:
+
+- Use an [OCI registry proxy](https://github.com/container-registry/helm-charts-oci-proxy) that has internet access and can fetch the chart and images on demand.
+- Mirror the chart and images manually, as described below, if you do not have or do not want to use a registry proxy.
+
+The remaining steps assume you are using the manual mirroring approach and complete them on an internet-connected machine before deploying to the cluster.
 
 **1. Get the chart**
 
@@ -760,12 +765,9 @@ Both sources ship with all chart dependencies already bundled — no `helm depen
 Inject your private registry as the default and push the chart to your internal OCI registry:
 
 ```sh
-# Set your private image registry as the default
-yq -i '.global.imageRegistry = "<your-private-registry>"' console/values.yaml
-
 # Repackage and push to your internal OCI registry
-tar czf console-<version>.tgz console/
-helm push console-<version>.tgz oci://<your-chart-registry>
+helm pull conduktor/console
+helm push console-<version>.tgz oci://<your-chart-registry>/console
 ```
 
 **3. Mirror the Console images**
@@ -793,8 +795,13 @@ Configure your cluster to authenticate to your private registry. The recommended
 **5. Install**
 
 ```sh
-helm install my-console oci://<your-chart-registry>/console --version <version>
+helm install my-console oci://<your-chart-registry>/console \
+  --version <version> \
+  --set global.imageRegistry=<your-private-registry> \
+  --set global.imagePullSecrets={registry-creds-secret}
 ```
+
+In practice, you'll usually put these overrides in a values file instead of passing them inline with `--set`.
 
 ### Store platform data on a Persistent Volume
 


### PR DESCRIPTION
## What

Adds an **Install in an air-gapped environment** section to the Console Helm chart README, mirroring the equivalent section in the [Gateway chart README](https://github.com/conduktor/conduktor-public-charts/blob/main/charts/gateway/README.md#air-gapped-deployment).

The section covers the five steps to run on an internet-connected machine before deploying to a disconnected cluster:

1. Get the chart (`helm pull conduktor/console`) — dependencies ship bundled, so no `helm dependency build`.
2. Repackage the chart for a private OCI registry, injecting `global.imageRegistry`.
3. Mirror both Console images: `conduktor/conduktor-console` and `conduktor/conduktor-console-cortex`.
4. Set up registry authentication (cloud-native, e.g. IRSA on EKS, or `global.imagePullSecrets`).
5. Install from the internal OCI registry.

It is linked from both the **Console configuration** quick links and the **Kubernetes configuration** table of contents.

## Adapted for Console

- Chart name `console` (from `Chart.yaml`) in the pull/repackage/install commands.
- Two images mirrored instead of one, matching the `platform` and `platformCortex` image blocks in `values.yaml`.
- Registry-auth step links to the existing `#pulling-from-private-registry-using-globalimagepullsecrets` section.

## Verification

- Both `platform.image` (`conduktor/conduktor-console`) and `platformCortex.image` (`conduktor/conduktor-console-cortex`) confirmed in `charts/console/values.yaml`.
- The `common` dependency is vendored in `charts/console/charts/`, so a `helm pull` ships it bundled — consistent with the "no `helm dependency build` needed" note.
- Anchors match the generated GitHub heading slugs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)