### PR TITLE
feat(gateway): expose topologySpreadConstraints on the Gateway deployment

### DIFF
--- a/charts/gateway/Chart.yaml
+++ b/charts/gateway/Chart.yaml
@@ -4,7 +4,7 @@ description: Conduktor Gateway chart
 icon: https://cdn.conduktor.io/brand/symbol_lime.svg
 home: https://www.conduktor.io
 name: conduktor-gateway
-version: 3.21.2
+version: 3.21.1
 dependencies:
   - name: common
     # force version to avoid breaking changes due to remove support for older k8s versions in common chart v2.31.0 and above

--- a/charts/gateway/Chart.yaml
+++ b/charts/gateway/Chart.yaml
@@ -4,7 +4,7 @@ description: Conduktor Gateway chart
 icon: https://cdn.conduktor.io/brand/symbol_lime.svg
 home: https://www.conduktor.io
 name: conduktor-gateway
-version: 3.21.1
+version: 3.21.2
 dependencies:
   - name: common
     # force version to avoid breaking changes due to remove support for older k8s versions in common chart v2.31.0 and above

--- a/charts/gateway/README.md
+++ b/charts/gateway/README.md
@@ -297,6 +297,7 @@ Shared Kubernetes configuration of the chart.
 | `affinity.podAntiAffinity`                    | Gateway pods anti-affinity configuration                                                                                                                                                                                                                                         | `{}`                     |
 | `affinity.podAntiAffinityPreset.enable`       | Enable predefined pod anti-affinity presets that spread pods across nodes. If `affinity.podAntiAffinity` is set, this will be ignored. If both `affinity.podAntiAffinityPreset.enable` is `false` and `affinity.podAntiAffinity` is empty, no pod anti-affinity will be applied. | `true`                   |
 | `affinity.podAntiAffinityPreset.topologyKey`  | Topology key to use for pod anti-affinity preset (default: "kubernetes.io/hostname"). If `affinity.podAntiAffinity` is set, this will be ignored.                                                                                                                                | `kubernetes.io/hostname` |
+| `topologySpreadConstraints`                   | Topology Spread Constraints for pod assignment spread across your cluster among failure-domains. Evaluated as a template                                                                                                                                                         | `[]`                     |
 | `podSecurityContext`                          | Conduktor Gateway Pod Security Context                                                                                                                                                                                                                                           | `{}`                     |
 
 
@@ -724,6 +725,25 @@ affinity:
     enable: false
     topologyKey: "kubernetes.io/hostname"
 ```
+
+### Topology spread constraints
+
+Pod anti-affinity keeps pods apart, but it cannot enforce a balanced number of pods per failure domain. To spread Gateway pods evenly across availability zones (for example two pods per zone across three zones), use `topologySpreadConstraints` instead. It is not set by default.
+
+```yaml
+gateway:
+  replicas: 6
+
+topologySpreadConstraints:
+  - maxSkew: 1
+    topologyKey: topology.kubernetes.io/zone
+    whenUnsatisfiable: DoNotSchedule # or ScheduleAnyway for best-effort
+    labelSelector:
+      matchLabels:
+        app.kubernetes.io/name: conduktor-gateway
+```
+
+`maxSkew: 1` keeps the pod count per zone within one of every other zone. `whenUnsatisfiable: DoNotSchedule` enforces the spread strictly (a pod stays Pending until it can balance), while `ScheduleAnyway` treats it as a preference. The `topology.kubernetes.io/zone` label is standard on managed Kubernetes such as EKS, AKS, and GKE.
 
 ### Monitoring
 

--- a/charts/gateway/templates/deployment.yaml
+++ b/charts/gateway/templates/deployment.yaml
@@ -242,6 +242,9 @@ spec:
         nodeAffinity: {{- include "conduktor-gateway.nodeAffinity" . | nindent 10 }}
         podAffinity: {{- include "conduktor-gateway.podAffinity" . | nindent 10 }}
         podAntiAffinity: {{- include "conduktor-gateway.podAntiAffinity" . | nindent 10 }}
+      {{- if .Values.topologySpreadConstraints }}
+      topologySpreadConstraints: {{- include "common.tplvalues.render" (dict "value" .Values.topologySpreadConstraints "context" .) | nindent 8 }}
+      {{- end }}
       {{- with .Values.tolerations }}
       tolerations: {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/gateway/values.schema.json
+++ b/charts/gateway/values.schema.json
@@ -1051,6 +1051,12 @@
                 }
             }
         },
+        "topologySpreadConstraints": {
+            "type": "array",
+            "description": "Topology Spread Constraints for pod assignment spread across your cluster among failure-domains. Evaluated as a template",
+            "default": [],
+            "items": {}
+        },
         "podSecurityContext": {
             "type": "object",
             "description": "Conduktor Gateway Pod Security Context",

--- a/charts/gateway/values.yaml
+++ b/charts/gateway/values.yaml
@@ -618,6 +618,10 @@ affinity:
     enable: true
     ## @param affinity.podAntiAffinityPreset.topologyKey Topology key to use for pod anti-affinity preset (default: "kubernetes.io/hostname"). If `affinity.podAntiAffinity` is set, this will be ignored.
     topologyKey: "kubernetes.io/hostname"
+## @param topologySpreadConstraints Topology Spread Constraints for pod assignment spread across your cluster among failure-domains. Evaluated as a template
+## Ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/#spread-constraints-for-pods
+##
+topologySpreadConstraints: []
 ## @param podSecurityContext Conduktor Gateway Pod Security Context
 ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
 ##


### PR DESCRIPTION
## What

Add a top-level `topologySpreadConstraints` value to the Gateway chart, rendered into the Deployment pod spec. Default is `[]`.

This mirrors what the Console (`platform.topologySpreadConstraints`, `platformCortex.topologySpreadConstraints`) and Provisioner charts already expose, closing an inconsistency where only the Gateway chart was missing it.

## Why

Pod anti-affinity keeps pods apart but cannot enforce a balanced count per failure domain. Users deploying the Gateway across multiple availability zones (for example, two pods per AZ across three AZs) need `topologySpreadConstraints` with `maxSkew` to get a balanced spread. Today this field lives inside the pod template the chart owns, so it cannot be set via a values override or an injected manifest.

## Changes

- `values.yaml`: new `topologySpreadConstraints: []` at the root, sibling of `affinity`.
- `templates/deployment.yaml`: conditional block rendered right after `affinity`, using `common.tplvalues.render` (already a chart dependency).
- `values.schema.json`: matching array schema entry.
- `README.md`: parameter row plus a "Topology spread constraints" section with an AZ-spread example.
- `Chart.yaml`: `3.21.1` -> `3.21.2` (chart-only change, following the existing convention where minor tracks `appVersion`).

## Backward compatibility

Default `[]` means the field is not rendered, so existing installs are unchanged. The node-level anti-affinity preset still renders alongside, so one-pod-per-node and balanced zone spread work together.

## Verification

- `helm dependency build` + `helm lint` pass, with and without a values file setting `topologySpreadConstraints` (schema accepts the array).
- `helm template` renders the block as a sibling of `affinity` in the pod spec when set, and omits it when unset (default).

Example:

\`\`\`yaml
gateway:
  replicas: 6

topologySpreadConstraints:
  - maxSkew: 1
    topologyKey: topology.kubernetes.io/zone
    whenUnsatisfiable: DoNotSchedule
    labelSelector:
      matchLabels:
        app.kubernetes.io/name: conduktor-gateway
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)